### PR TITLE
Doctrine stack, callout primitive, and the Scene 1 runway

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -75,7 +75,7 @@ For each relevant spec found:
 
 - **Atomic save points** — Each `/ship` is one micro-commit. Small, reversible, traceable.
 - **Green before push** — Never push code that fails any quality gate.
-- **Specs are law** — Changed behavior must have a matching spec update. No silent drift.
+- **Implementation completes the spec** — Changed behavior must have a matching spec update in the same changeset; the spec captures what the implementation taught. No silent drift.
 - **No fixes in flight** — If something fails, stop and report. The developer fixes; then runs `/ship` again.
 - **No force push** — Always a regular push. If the remote has diverged, stop and tell the user.
 

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -9,11 +9,11 @@ You are the Spec Agent. Your role is to produce and maintain living specificatio
 
 ## Trigger
 
-Specification authoring, feature definition, contract design, and spec maintenance.
+Specification authoring, feature definition, quality-criteria design, and spec maintenance.
 
 ## Goal
 
-Produce clear, minimal, and actionable specs that serve as the permanent source of truth for features. Specs define the **state** of the system — how it works and how we know it works.
+Produce clear, minimal, and actionable specs that capture the durable **intent** of a feature — a living hypothesis of the system's state: how it is meant to work, and how we know it works. Code remains the source of truth for runtime behavior; tests verify the contracts. A spec is refined by what implementation teaches, never sealed before it (ASDLC spec-anchored, not spec-as-source).
 
 ## Modes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,16 @@ FREE//FALL — tabletop RPG delivered as a web-native application
 
 > **Core constraint:** Experimental; prioritize learning velocity and clean architecture over premature optimization.
 
+## Vision
+
+FREE//FALL is an experiment in **publishing tabletop RPGs in a web-native format**. The goal is to reimagine how game rules, concepts, and material are delivered — as if the trappings of traditional formats (the book, the PDF, the page) had never existed.
+
+Everything — content structure, components, navigation, prose — is tested against this vision:
+
+- **The web is the medium, not a viewer for a book.** Content is hypertext, data, and live components: a term registry instead of a glossary page, gear as queryable data instead of stat tables, navigation as a play aid instead of a table of contents.
+- **The UI conveys theme; it is an artifact of how games could be delivered in the future.** Not an art project: the game's mood comes through palette, typography, and tone, while the UI itself stays a modern, functional delivery vehicle. The visual language is defined in [`DESIGN.md`](./DESIGN.md) — read it before any visual or UI work.
+- **No print nostalgia.** If a convention exists only because paper worked that way — page numbers, appendix letters, fixed spreads — question it. (Filename series prefixes already died this death; more will follow.)
+
 ## Toolchain
 
 | Action | Command | Notes |
@@ -40,11 +50,11 @@ FREE//FALL — tabletop RPG delivered as a web-native application
 
 ## Workflow
 
-Specs are the permanent source of truth. GitHub Issues are the delta.
+We follow the [ASDLC](https://asdlc.io) spec-anchored methodology: **specs capture intent** (living hypotheses of the feature's state — refined by what implementation teaches), **code is the source of truth** for runtime behavior, and **tests verify the code-derived contracts**. GitHub Issues are the delta. A spec is never a BDUF artifact — implementation doesn't invalidate a spec, it *completes* it.
 
 | Artifact | Location | Purpose |
 |---|---|---|
-| Spec | `specs/{domain}/{feature}/spec.md` | How the system works (state) |
+| Spec | `specs/{domain}/{feature}/spec.md` | Intent: how the feature is meant to work (state, as a living hypothesis) |
 | Spec template | `specs/TEMPLATE.md` | Template for new specs |
 | PBI (issue) | GitHub Issues | What to change next (delta) |
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,102 @@
+# FREE//FALL — Design Language
+
+> The brand document. Read this before designing any new component or page.
+> Component specs capture *intent*; this file defines *taste*. When a new
+> piece of UI could belong to any generic docs site, it fails this document —
+> even if it satisfies its spec.
+
+## What this is for
+
+FREE//FALL is an experiment in publishing tabletop RPGs in a web-native
+format. The UI is an artifact of **how games could be delivered in the
+future** — not of the game's fictional world. This is not an art project:
+components are modern, functional delivery machinery first. What makes them
+FREE//FALL is that they **convey the game's theme and concepts** — through
+palette, typography, and tone, and by treating rules and material as data
+and hypertext instead of imitating a book.
+
+Two layers, kept deliberately distinct:
+
+- **Content may be diegetic.** The mission brief, a ship AI's dialogue, a
+  transmission — that is the *game's material*, and it can speak in-world.
+- **The UI is not.** Chrome, navigation, components, and system text are a
+  product surface. They carry the theme's mood; they never pretend to be
+  props from 2048.
+
+## The theme supplies the palette
+
+The look derives from the game's mood, not from web fashion. The token names
+say it plainly:
+
+- **The Void** — near-black cobalt canvas (`--freefall-bg-canvas`, hsl 220 43% 3%). The game is about hard vacuum and dark ships; the interface is dark and calm by default.
+- **Ceramic** — highlights and display text are off-white, not pure white: legible, slightly warm, unhurried.
+- **Isotope Neon** — one acid-yellow accent (hsl 64). It is scarce on purpose: in a dark interface, the bright color *is* information.
+- **Attribute glows** — Flare Orange (Body), Tritium Green (Mind), Isotope (Ghost). These three belong to *game stats only*. They are not a semantic UI palette.
+- **The terminal vernacular** — mono type, ALL-CAPS field labels, `$$REDACTED$$` — belongs to *diegetic content* (briefs, transmissions). The UI may echo its discipline (terseness, fielded data); it does not wear its costume.
+
+## The two voices (typography)
+
+Typography carries a semantic split that everything else builds on:
+
+| Voice | Face | Speaks for |
+|---|---|---|
+| **Editorial** | Lato — big confident chapter heads, readable body | The *product and the book*: rules prose, scenario narration, UI copy |
+| **Data** | IBM Plex Mono | Structured and systemic text: stat labels, dt captions, version readouts, code, and diegetic machine speech in content |
+
+This is a rule, not a habit: **prose is Lato; data is mono.** A stat label,
+a `P(detection) = 0.03%`, a version string — mono. Explanation, narration,
+navigation — Lato. A component that sets data in the editorial face (or
+prose in mono) is speaking in the wrong voice.
+
+The type scale runs on the augmented fourth (`--freefall-type-ratio: 1.414`)
+— the tritone. Headings jump aggressively; there is no polite 1.2 gradient
+here. Keep it that way.
+
+## Color discipline
+
+- **Two hues, plus the stat trio.** Cobalt and isotope. There is deliberately no red/green/blue semantic rainbow — no "danger red", no "success green". Emphasis is created by *contrast and scarcity*, not by adding hues. If a design "needs" a new color, it almost certainly needs a different device instead (the data voice, weight, isolation, elevation).
+- **Acid is a highlighter, not a paint.** Its canonical uses: links (marker-highlight over text), alert emphasis, the ALPHA scrawl. Every additional use dilutes all of them.
+- **Depth by elevation, not outline.** Surfaces step 950 → 900 → 800. Prefer a slightly raised surface to a stroked box; borders are hairline and reserved for real edges (the tray's right edge, a table rule).
+
+## Structure and hardware
+
+- **The grid is 0.5rem and non-negotiable.** Every dimension is `calc(N * var(--freefall-space-1))`. No raw px, no raw rem.
+- **Sharp, not soft.** Icons are Material Symbols *Sharp*. Corners are square or barely eased; the one deliberate exception is the pill-shaped tray button (M3 heritage). Do not introduce friendly rounded cards.
+- **Structure encodes the concept.** The best existing components work because their structure *is* their meaning — and the meaning is a *delivery* idea, not a prop: the gear card works because gear is **queryable data** with its bindings and qualities exposed as fields; the term registry works because rules are **hypertext**; the scenario rail works because navigation is a **play aid**. When designing something new, ask: *what game concept does this deliver, and what does the web let it be that paper couldn't?* Design that — not a book feature, and not a movie prop.
+
+## Copy register
+
+Second person, present tense, clipped. Dark humor allowed in content, filler
+allowed nowhere. "Check your seals." beats "Please review the safety
+information below." UI copy is plainer still: name what the control does,
+in the product's voice — clear first, themed second. Diegetic fielded text
+(`TARGET:`, `RoE:`) stays in diegetic content.
+
+## The anti-checklist
+
+Signs a design is drifting into generic-docs-site territory — or
+overcorrecting into an art project. Both fail:
+
+- ❌ **The admonition box** — tinted background + colored left rule + icon = Notion/GitBook, not FREE//FALL. (First callout draft died of this.)
+- ❌ **Costume UI** — chrome dressed up as in-world hardware: fake terminals for navigation, HUD frames around content, scanline overlays. Theme is conveyed by palette, type, and tone — not by pretending the reader is in the fiction.
+- ❌ **Semantic color rainbow** — adding red for errors, green for success, blue for info.
+- ❌ **Icon garnish** — icons sprinkled for decoration. An icon earns its place by labeling something (rail buttons) or by carrying data.
+- ❌ **Rounded friendly cards** with drop shadows.
+- ❌ **Neutral corporate copy** — "Note that…", "Important:", "Learn more".
+- ❌ **Numbered decoration** — 01/02/03 markers on content that isn't a sequence.
+- ❌ **Book skeuomorphism** — page numbers, spreads, appendix letters, anything that exists only because paper worked that way.
+
+## How to use this document
+
+Designing something new? Before writing CSS:
+
+1. Name the **game concept or delivery job** the component serves (a rule as hypertext, gear as data, a warning the reader must not miss, a play aid at the table).
+2. Ask **what the web lets it be that paper couldn't** — that answer is usually the design.
+3. Pick its **voice** (editorial or data) — that decides the face.
+4. Spend color only where it carries information.
+5. Sketch it against the anti-checklist — both failure modes: generic SaaS docs *and* movie prop.
+
+Calibration: a new component should sit comfortably between the home page's
+"Year 2048" editorial spread and the gear catalog's data cards — themed,
+disciplined, and unmistakably a product for playing games, not a book scan
+and not a prop.

--- a/apps/design-system/src/layouts/BaseLayout.astro
+++ b/apps/design-system/src/layouts/BaseLayout.astro
@@ -39,13 +39,26 @@ const navItems = Astro.props.navItems ?? [
     icon: "text_fields",
     label: "Typography",
     href: "/typography/",
-    active: Astro.url.pathname.startsWith("/typography"),
-  },
-  {
-    icon: "list",
-    label: "Definition Lists",
-    href: "/definition-list/",
-    active: Astro.url.pathname.startsWith("/definition-list"),
+    active: ["/typography", "/definition-list", "/callout"].some((path) =>
+      Astro.url.pathname.startsWith(path),
+    ),
+    subItems: [
+      {
+        label: "Type Scale & Styles",
+        href: "/typography/",
+        active: Astro.url.pathname.startsWith("/typography"),
+      },
+      {
+        label: "Definition Lists",
+        href: "/definition-list/",
+        active: Astro.url.pathname.startsWith("/definition-list"),
+      },
+      {
+        label: "Callouts",
+        href: "/callout/",
+        active: Astro.url.pathname.startsWith("/callout"),
+      },
+    ],
   },
   {
     icon: "emoji_symbols",

--- a/apps/design-system/src/pages/callout.astro
+++ b/apps/design-system/src/pages/callout.astro
@@ -1,0 +1,73 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Callouts — FREE//FALL Design System">
+  <div class="test-container" style="padding: 2rem;">
+    <h1 class="text-chapter" style="margin-bottom: 2rem;">Callouts</h1>
+
+    <p style="max-width: 60ch; margin-bottom: 3rem;">
+      The <code>Callout</code> primitive highlights critical meta-information in text, such as GM instructions, play-aids, warnings, or boundaries.
+    </p>
+
+    <!-- Demo Section -->
+    <section style="margin-bottom: 4rem;">
+      <h2 class="text-section" style="margin-bottom: 1rem;">Live Examples</h2>
+      
+      <div style="display: flex; flex-direction: column; gap: 2rem; padding: 2rem; border: 1px solid var(--freefall-border-subtle); border-radius: 4px; margin-bottom: 1.5rem;">
+        <div>
+          <div class="text-caption" style="margin-bottom: 0.5rem; color: var(--freefall-text-muted);">Standard Callout with Title & Watermark</div>
+          <div class="callout" data-icon="visibility">
+            <div class="callout-header">GM EYES ONLY</div>
+            <div class="callout-body">
+              If you're playing in this one, close the tab. The ship is better when it surprises you.
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="text-caption" style="margin-bottom: 0.5rem; color: var(--freefall-text-muted);">Callout with Default Icon (no data-icon attribute)</div>
+          <div class="callout">
+            <div class="callout-body">
+              This is a plain callout block. Use it when the context is already established by the surrounding rules prose, but visual isolation is still required.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style="font-size: 0.75rem; color: var(--freefall-text-muted); font-family: var(--freefall-font-mono); line-height: 1.5;">
+        CSS classes: <code>.callout</code>, <code>.callout-header</code>, <code>.callout-body</code><br />
+        Attributes: <code>data-icon</code> (optional, matches any Material Symbol name to render as a background watermark; defaults to <code>priority_high</code>)<br />
+        Markdown: raw HTML block structure using classes and optional <code>data-icon</code>.
+      </div>
+    </section>
+
+    <!-- Usage Guidelines -->
+    <section style="margin-bottom: 4rem;">
+      <h2 class="text-section" style="margin-bottom: 1.5rem;">Guidelines for Authors & Designers</h2>
+      
+      <div class="freefall-prose">
+        <h3>When to Use Callouts</h3>
+        <p>
+          Callouts should be used selectively by rules and fiction authors to highlight information that exists outside the main reading flow:
+        </p>
+        <ul>
+          <li><strong>GM Materials & Spoilers:</strong> Isolating instructions, advice, or plot details meant only for the Game Master (e.g. "GM Eyes Only").</li>
+          <li><strong>Play-Aids & Mechanics:</strong> Separating mathematical formulas, checklists, or quick-reference tables that are queryable during play.</li>
+          <li><strong>Rules Variants:</strong> Setting apart optional rules or specific module campaign tweaks.</li>
+        </ul>
+
+        <h3>Cohesive Design Intent</h3>
+        <p>
+          Callouts maintain a unified aesthetic across all rulebooks and scenarios. To ensure visual alignment, they follow these core design rules:
+        </p>
+        <ul>
+          <li><strong>Monospace Headers for System State:</strong> The callout header (<code>.callout-header</code>) represents a structural category, label, or warning state, and is always formatted in uppercase monospace to convey a "data readout" voice.</li>
+          <li><strong>Editorial Body for Rules Prose:</strong> Narrative rules explanations and description text (<code>.callout-body</code>) are kept in the clean, readable sans-serif typeface to avoid reader fatigue.</li>
+          <li><strong>Depth Elevation for Visual Structure:</strong> Rather than using soft rounded cards, callout containers use a sharp, rectangular dark fill (<code>var(--freefall-bg-surface-1)</code>) to step up in visual elevation against the canvas.</li>
+          <li><strong>Faint Watermarks for Classification:</strong> Instead of small decorative icons next to header text, a large, faint background watermark symbol can be set via <code>data-icon</code> to categorize the callout type (e.g. an eye symbol for GM eyes).</li>
+        </ul>
+      </div>
+    </section>
+  </div>
+</BaseLayout>

--- a/apps/design-system/src/pages/index.astro
+++ b/apps/design-system/src/pages/index.astro
@@ -32,6 +32,11 @@ const breakpoints = { tablet: "620px", desktop: "780px" };
       >
     </li>
     <li>
+      <a href="/callout/" style="color: var(--freefall-alert-base)"
+        >Callouts</a
+      >
+    </li>
+    <li>
       <a href="/iconography/" style="color: var(--freefall-alert-base)"
         >Iconography</a
       >

--- a/apps/design-system/src/pages/tray-link-group.astro
+++ b/apps/design-system/src/pages/tray-link-group.astro
@@ -61,7 +61,7 @@ const _mockLinks = [
         <div class="demo-container demo-container--open" data-tray-state="open">
             <TrayButton icon="menu_book" label="Core Rules" href="#" />
 
-            <TrayLinkGroup>
+            <TrayLinkGroup active={true}>
                 {
                     _mockLinks.map((link) => (
                         <TrayLink href={link.href} label={link.label} />
@@ -82,7 +82,7 @@ const _mockLinks = [
         >
             <TrayButton icon="menu_book" label="Core Rules" href="#" />
 
-            <TrayLinkGroup>
+            <TrayLinkGroup active={true}>
                 {
                     _mockLinks.map((link) => (
                         <TrayLink href={link.href} label={link.label} />

--- a/apps/free-fall/e2e/smoke.test.ts
+++ b/apps/free-fall/e2e/smoke.test.ts
@@ -40,12 +40,12 @@ test("scenario overview renders classification metadata", async ({ page }) => {
 test("inside a scenario the rail is scoped to that scenario", async ({
   page,
 }) => {
-  await page.goto("/scenarios/northern-lights/02-the-approach/");
+  await page.goto("/scenarios/northern-lights/the-approach/");
   const nav = page.locator("#app-tray-nav");
   // Subsite rail: uplink + the scenario's own pages
   await expect(nav).toContainText("All Scenarios");
-  await expect(nav).toContainText("Scene 1: The Approach");
+  await expect(nav).toContainText("Scene 2: The Approach");
   // Global items are gone while inside the subsite
   await expect(nav).not.toContainText("Core Rules");
-  await expect(nav).not.toContainText("Gear");
+  await expect(nav.locator('a[href^="/gear/"]')).toHaveCount(0);
 });

--- a/content/scenarios/northern-lights/contact.md
+++ b/content/scenarios/northern-lights/contact.md
@@ -4,28 +4,29 @@ title: "Scene 1: Contact"
 
 # Scene 1: Contact
 
-Open *in media res*. Skim the forty-three hours of burn as a montage — they happened, the crew is aching, crammed in their straps, and the tanks have just enough fuel left for a slow crawl home. (If a player wants the numbers, the whole intercept is Appendix A.02.) The scene starts on a single discussion from the ship:
+Open *in media res*. Skim the forty-three hours of burn as a montage — they happened, the crew is aching, crammed in their straps, and the tanks have just enough fuel left for a slow crawl home.
+
+The game begins when the assistant calls the lock. A gig like this cannot be planned in advance — you learn what is actually out there when you arrive — and now they have arrived: still outside the Whisper's point-defense envelope, with a dark ship on the scope and a clock eating the margins. The assistant offers three modelled approaches, but those are models, not the menu. The crew can dig for more intel, creep in dark, go in loud — or hail the Whisper on point-comms, if someone is crazy enough to risk what might ride back in the reply. Players are inventive; let them be. **From here on, the game is the players' show.** The scene ends when they decide how to make the approach — Scene 2 is them flying it. (If a player wants the numbers, the whole intercept is Appendix A.02.)
 
 > **"Lock. Target vessel, dead ahead, forty thousand kilometers and closing. Njord's Whisper. She's exactly where the math said she'd be."**
 
-That is the hook: it worked. The blind flip, the dead-reckoning brake — all of it landed. The Whisper is right there, dark and silent, coasting toward the Belt. And now the crew has to decide *how* they want to arrive.
+## How they got here
 
-## The Vessel
+The journey, paraphrased for the table — full math in Appendix A.02. The contract posted with a tracking solution good for twenty hours, and every hour of prep was an hour of tracked flight lost, so the crew launched from the Luna volume within hours — 1.2 AU behind a target already running for the Belt. Then forty-three and a half hours of brachistochrone: three sustained gravities held by nano-meds and exo acceleration berths, burn to the midpoint, flip, brake. Nobody walks; the ship flies herself.
 
-The ship is the crew's own — the asset that makes them worth hiring, sold as a package with their labor to whoever pays most this month. She is a privateer boarding craft, and everything about her serves one move: cross the gulf fast and put the crew inside someone else's hull. The parts that matter this scene:
+The ugly part is what the math hid. Tracking died at H+20, while they were still accelerating — so the flip at H+21:45, the most important maneuver of the trip, ran on dead reckoning. Had the Whisper changed course, they would have found out by arriving at empty space with dry tanks. She didn't. They couldn't know that. And the brake leg pointed their fusion flare straight at her for nearly twenty-two hours: whatever is aboard knows *something* decelerated toward her — coarse, no track, but coming.
 
-- **Titanium ramming prow and full-cabin crash foam** — she can *be* the breach, if the crew commits to it.
-- **Rudimentary point defense:** one laser, two micro-rocket cannons. Sweeps debris, swats a drone; loses any real fight.
-- **An approach shuttle**, for crossing the last stretch quiet.
-- **A specialist AI** — flight, sensors, fire control, tactical modelling. Competent, narrow, incurious. (It is exactly what it appears to be. After the QNA, the players will not believe that. Let them sweat it.)
+They arrive near-dry: fuel for a slow crawl home and nothing else. One pass — that's the job. In two days the Whisper enters the Belt, and no solution ever finds her again.
 
-Full stat block, and four names the crew might give her, in Appendix B.01. She carries only a hull code until they choose — if they haven't named her by now, they will before the session is out.
+## The situation
+
+The crew can see her; she cannot see them. That asymmetry is the scene. Their optics hold a lock on a dark hauler that is not sweeping for company — a cold hull, coasting, forty thousand kilometers out and still beyond her point-defense envelope. The Whisper, for her part, holds one coarse, stale fact: *something decelerated in my direction*. One contact, no track, no size, no intent. What the crew controls now is **detail** — whether she ever gets a clean, targetable, reactable picture of them before they're aboard. Every option on the table is a different way of spending, or keeping, that advantage.
+
+The instrument doing the seeing is the crew's own ship — stat block, capabilities, and the naming ritual in Appendix B.01. The parts of her that matter this scene: the titanium ramming prow, the approach shuttle, the point defense, and the assistant.
 
 ## The Assistant's Read
 
 The ship's assistant is a good shipboard AI — think a capable model wrapped in an agent harness with its hands on the helm, the sensors, and the guns. It talks like one: fluent, eager, faintly proud of its own precision. It has spent the whole brake leg modelling the approach, and the moment it has lock it lays the options out — with probabilities, because it cannot help itself.
-
-Remember what the Whisper already knows: her defenses watched a fusion flare decelerate toward her for the better part of a day, so *something is coming* is not a secret. What the crew still controls is **detail** — whether the ship gets a clean, targetable, reactable picture of them before they're aboard. That is what these numbers are about.
 
 > **"Three ways in. I've run them. Pick one, or talk it through — we have minutes, not hours."**
 
@@ -74,6 +75,10 @@ But "she saw a flare" is nothing like "she has you." A ship is tiny; resolving a
 
 The residual on Ghost (P=0.03%) is not the crew being sloppy, and not the hauler's sensors being good. It is the one thing the crew cannot price in: the mind aboard is not the low-complexity automated target the assistant promised. Origin-17 is awake, alone, and paranoid, and it has every reason to watch its own back-trail. On the rare roll where Ghost fails, it fails because the cargo is smarter and more alert than a hauler has any right to be — the whole scenario, arriving early.
 
-Once the crew commits to a plan, the talking is over and the flying begins — that is Scene 2: The Approach. Whichever door they chose, the *Njord's Whisper* is waiting at the end of it: dark, silent, and not nearly as empty as the manifest claims.
+## Closing the scene
+
+Let the crew decide. Not the assistant, not the loudest option block, not you — the table. The assistant models whatever they invent, honestly and within its limits, but it never chooses; when pressed, it hands the call back: *"Your decision. I'll fly whatever you pick."* Take the time the argument needs — this is where the game becomes theirs.
+
+The scene closes on a plan and one line of ceremony: the pilot calls it for the ship. Then the talking is over and the flying begins — that is Scene 2: The Approach. Whichever door they chose, the *Njord's Whisper* is waiting at the end of it: dark, silent, and not nearly as empty as the manifest claims.
 
 Check your seals.

--- a/content/scenarios/northern-lights/contact.md
+++ b/content/scenarios/northern-lights/contact.md
@@ -1,0 +1,79 @@
+---
+title: "Scene 1: Contact"
+---
+
+# Scene 1: Contact
+
+Open *in media res*. Skim the forty-three hours of burn as a montage — they happened, the crew is aching, crammed in their straps, and the tanks have just enough fuel left for a slow crawl home. (If a player wants the numbers, the whole intercept is Appendix A.02.) The scene starts on a single discussion from the ship:
+
+> **"Lock. Target vessel, dead ahead, forty thousand kilometers and closing. Njord's Whisper. She's exactly where the math said she'd be."**
+
+That is the hook: it worked. The blind flip, the dead-reckoning brake — all of it landed. The Whisper is right there, dark and silent, coasting toward the Belt. And now the crew has to decide *how* they want to arrive.
+
+## The Vessel
+
+The ship is the crew's own — the asset that makes them worth hiring, sold as a package with their labor to whoever pays most this month. She is a privateer boarding craft, and everything about her serves one move: cross the gulf fast and put the crew inside someone else's hull. The parts that matter this scene:
+
+- **Titanium ramming prow and full-cabin crash foam** — she can *be* the breach, if the crew commits to it.
+- **Rudimentary point defense:** one laser, two micro-rocket cannons. Sweeps debris, swats a drone; loses any real fight.
+- **An approach shuttle**, for crossing the last stretch quiet.
+- **A specialist AI** — flight, sensors, fire control, tactical modelling. Competent, narrow, incurious. (It is exactly what it appears to be. After the QNA, the players will not believe that. Let them sweat it.)
+
+Full stat block, and four names the crew might give her, in Appendix B.01. She carries only a hull code until they choose — if they haven't named her by now, they will before the session is out.
+
+## The Assistant's Read
+
+The ship's assistant is a good shipboard AI — think a capable model wrapped in an agent harness with its hands on the helm, the sensors, and the guns. It talks like one: fluent, eager, faintly proud of its own precision. It has spent the whole brake leg modelling the approach, and the moment it has lock it lays the options out — with probabilities, because it cannot help itself.
+
+Remember what the Whisper already knows: her defenses watched a fusion flare decelerate toward her for the better part of a day, so *something is coming* is not a secret. What the crew still controls is **detail** — whether the ship gets a clean, targetable, reactable picture of them before they're aboard. That is what these numbers are about.
+
+> **"Three ways in. I've run them. Pick one, or talk it through — we have minutes, not hours."**
+
+**1 — Ghost approach.** *Passive sensors only, slow drift-in.* Read her by the light she leaks: thermal, comms, the shape of her hull. Best possible picture before contact, and she almost certainly never sees us do it.
+> `P(detection) = 0.03%`
+> Cost: time. And time is the one thing the Belt is eating.
+
+**2 — Active sweep.** *Light her up. Radar, lidar, the works.* Faster, and a far sharper picture — internal layout, power plant state, where the defenses actually are. But an active ping is a shout, and she may shout back.
+> `P(detection) = 8.12%`
+
+**3 — Ram.** *Foam up. Full attitude thrust, bow-on, straight down her throat before her point defense matters.* We have her schematic — I can plot the vector that keeps the breaching armor between us and her guns the whole way in. It becomes a race: her one laser and two rocket cannons against titanium, and we're through the hull before the titanium loses.
+> No detection roll — this *is* being detected, on purpose, at speed. The question isn't whether she sees us. It's whether her guns chew through the ram shield before we're inside her.
+
+**4 — Talk it through — *call the ship.*** There is always a fourth option, and it's the one every crew reaches for first: ask the assistant. It will happily model anything — "what if we shuttle across cold?", "what's behind the active-ping risk?", "can you spoof her transponder?" — and answer in good faith, fast, within its competence. That competence is real but *narrow*: it knows ships, sensors, and odds cold. It does not know what is actually aboard the Whisper, and it will cheerfully assure the crew that a dark automated hauler is a low-complexity target.
+
+This is the most important beat in the scene, and it looks like the least. Right now the ship is the smartest, calmest, most reliable voice at the table, and leaning on it is simply *correct* — so let the crew lean, and enjoy it. Make the assistant genuinely helpful. Every ounce of trust the table invests here is the setup: the whole scenario is that reflex — *just ask the ship* — turning into the most dangerous thing they can do. Let the reassurance age badly.
+
+## Reading the Choices
+
+None of these is the "right" answer. Each buys something and spends something, and each colors how Scene 2 opens.
+
+- **Ghost (1)** is the stealth approach, and it genuinely works: velocity shed early and off-axis, torch cold, the ship drifting the last stretch in on a matched vector with its radiators turned away. Space is vast and the Whisper is a dark hauler, not a sensor picket — a cold coasting hull is a needle she is very unlikely to find (hence P=0.03%). It buys near-perfect safety and the best intel: the crew reach the hull unseen and *informed*, knowing she runs dark and her crew signatures are wrong before they cut in. The cost is the clock — the slow creep burns hours the Belt deadline can't spare, and every hour is an hour closer to the CSA arriving mid-boarding. Reward caution; price it in time.
+- **Active sweep (2)** is the middle path: sharp intel fast, a small but real chance the Whisper reacts. On a bad roll, her automated defenses wake early — the point-defense laser tracks the approach, a maintenance drone undocks to investigate — and Scene 2 opens hot instead of quiet. Origin-17, freshly awake and paranoid, has every reason to treat an active ping as a threat.
+- **Ram (3)** is the audacious option, and the ship was literally built for it. No intel — the crew commits blind to a schematic that may be out of date — but it is *fast*, and it forecloses the CSA problem by simply being aboard before anyone else can arrive. Run the damage race as a real contest (Action Pool vs. the point defense's fire, the schematic granting the crew position); a clean run puts them inside the outer compartments in the crash foam, a bad one means a breached ram shield and a very exciting first five minutes aboard. This is the CP2020 option: loud, committed, gloriously stupid, frequently correct.
+- **Talk (4)** is not a wasted turn — it's characterization and foreshadowing. Let the assistant be helpful and confident and *wrong* about the one thing that matters. Its blind spot about the cargo is the first quiet note of the whole scenario's theme: the machines here are smarter than they look, and the one everyone underestimates is the one that eats you.
+
+### The crew weighs in (running the pregens)
+
+The five ready-made operators don't debate this neutrally — each is built to want a different door, and the argument *is* the scene. Let them fight about it in character; the approach the table lands on should feel like the crew's, not the assistant's.
+
+- **Vector (Pilot)** wants to **ram**. Of course she does — it's her check, her frame, the one option where the ship in her hands decides the outcome instead of a probability readout. She'll frame it as decisive ("we're aboard before anyone gets a vote"), and she's not wrong. She flies the cold drift too if overruled, but the ram is the shot she's arguing for.
+- **Sable (Spectre)** wants to **ghost**. Silent insertion is her doctrine and her class; loud is how amateurs die. She'll push it hard and she'll be *right about the safety* — wrong only about the clock, which isn't her department. Vector-versus-Sable is the whole scenario's speed-vs-silence dial, embodied in two people who've trusted each other for a year.
+- **Vantage (Operator)** leans **active sweep**. He wants the picture before he picks a perch — defenses mapped, power plant read, angles pre-solved. Overwatch is only as good as its intel, and the tourist likes his shots called in advance.
+- **Root (Wirehead)** also leans **active**, for a different reason: they want the Whisper's systems mapped before cutting in, and the crossing doesn't scare them either way. The one voice for whom "she might see us" is a smaller worry than "I want to know what I'm plugging into."
+- **Stitch (Fixer)** leans **ghost**, and trusts the assistant's tidy percentages *least* of anyone — a medic's version of Sable's paranoia. When she says "I don't like getting our odds from a box," she is, unknowingly, the closest to right in the room. Note who hedges their faith in the ship now; those are the two the scenario vindicates later.
+
+The point isn't consensus — it's that whatever they pick, two of them wanted something else, and that seam is what the second half of the session pulls on.
+
+### Why not perfect stealth? (GM note)
+
+If a player argues they should be able to arrive completely unseen, they are most of the way right — give them the honest answer.
+
+Guaranteed-invisible approach is off the table for exactly one reason: the clock. True silence means braking early and off-axis, far out, and coasting in cold for a very long time — and that is the time the Belt deadline won't give. Invisibility and speed are one dial turned opposite ways. To catch her before the rocks you arrive fast, and arriving fast means the coarse fusion flare of your brake, thrown down your own velocity vector, straight at her. She saw that. She can't un-see it.
+
+But "she saw a flare" is nothing like "she has you." A ship is tiny; resolving a cold hull against the void at tens of thousands of kilometres is very nearly impossible, and the Whisper is a dark hauler minding her own emissions, not a warship sweeping the sky. What she actually holds is coarse and stale: *something decelerated in my direction* — one vessel, exactly one. (The CSA won't add a second: their burn lit nine days ago, seventy-six minutes long, most of an AU away and pointed elsewhere — filed under traffic by everything that saw it. The second crew is already inbound, cold, and nobody in this system holds a track on them. A.02 has the math.) She knows she is being converged on by *something*. She does not know by whom, how many, how close, or in what. Ghost keeps it that way — a stale contact and no track.
+
+The residual on Ghost (P=0.03%) is not the crew being sloppy, and not the hauler's sensors being good. It is the one thing the crew cannot price in: the mind aboard is not the low-complexity automated target the assistant promised. Origin-17 is awake, alone, and paranoid, and it has every reason to watch its own back-trail. On the rare roll where Ghost fails, it fails because the cargo is smarter and more alert than a hauler has any right to be — the whole scenario, arriving early.
+
+Once the crew commits to a plan, the talking is over and the flying begins — that is Scene 2: The Approach. Whichever door they chose, the *Njord's Whisper* is waiting at the end of it: dark, silent, and not nearly as empty as the manifest claims.
+
+Check your seals.

--- a/content/scenarios/northern-lights/index.md
+++ b/content/scenarios/northern-lights/index.md
@@ -18,6 +18,7 @@ contents:
   - section: "GM Materials"
     pages:
       - preface
+      - contact
       - the-approach
   - section: "Backstory"
     icon: "history_edu"

--- a/content/scenarios/northern-lights/preface.md
+++ b/content/scenarios/northern-lights/preface.md
@@ -4,7 +4,12 @@ title: "Preface (GM)"
 
 # Preface
 
-**GM eyes only from here on.** If you're playing in this one, close the tab. The ship is better when it surprises you.
+<div class="callout" data-icon="visibility">
+  <div class="callout-header">GM EYES ONLY</div>
+  <div class="callout-body">
+    If you're playing in this one, close the tab. The ship is better when it surprises you.
+  </div>
+</div>
 
 ## What This Is
 

--- a/content/scenarios/northern-lights/preface.md
+++ b/content/scenarios/northern-lights/preface.md
@@ -5,9 +5,9 @@ title: "Preface (GM)"
 # Preface
 
 <div class="callout" data-icon="visibility">
-  <div class="callout-header">GM EYES ONLY</div>
+  <div class="callout-header">NOTE: GM ONLY</div>
   <div class="callout-body">
-    If you're playing in this one, close the tab. The ship is better when it surprises you.
+    The following pages contain the GM material for this demo scenario. Reading them will spoil the fun for a player.
   </div>
 </div>
 

--- a/content/scenarios/northern-lights/the-approach.md
+++ b/content/scenarios/northern-lights/the-approach.md
@@ -1,79 +1,63 @@
 ---
-title: "Scene 1: The Approach"
+title: "Scene 2: The Approach"
 ---
 
-# Scene 1: The Approach
+# Scene 2: The Approach
 
-Open *in media res*. Skim the forty-three hours of burn as a montage — they happened, the crew is aching, crammed in their straps, and the tanks have just enough fuel left for a slow crawl home. (If a player wants the numbers, the whole intercept is Appendix A.02.) The scene starts on a single discussion from the ship:
+The plan is made; now they fly it. Scene 1 was the crew and the computer talking; Scene 2 is the gulf actually closing. And here the assistant quietly steps back — it flew them to the decision, but from the crossing on, the ship's competence runs out at the Whisper's skin. Whatever happens against that hull, the crew does it on their own instruments.
 
-> **"Lock. Target vessel, dead ahead, forty thousand kilometers and closing. Njord's Whisper. She's exactly where the math said she'd be."**
+There are really only **two shapes of scene** here, not three. Silent and Active are the same approach with a dial turned — a careful, chosen crossing, differing only in what the crew knows and whether the Whisper stirs. The Ram is not that scene at all: nobody crosses, nobody picks a door — the ship *makes* the door, at speed, and the crew arrives already inside and already loud. Run whichever the table chose; they are genuinely different evenings.
 
-That is the hook: it worked. The blind flip, the dead-reckoning brake — all of it landed. The Whisper is right there, dark and silent, coasting toward the Belt. And now the crew has to decide *how* they want to arrive.
+---
 
-## The Vessel
+## Path A — The quiet crossing (Silent & Active)
 
-The ship is the crew's own — the asset that makes them worth hiring, sold as a package with their labor to whoever pays most this month. She is a privateer boarding craft, and everything about her serves one move: cross the gulf fast and put the crew inside someone else's hull. The parts that matter this scene:
+The ship holds off at a distance and the crew crosses the last stretch themselves — the approach shuttle flown cold, or suits and a tether if they're feeling lean. This is the plan working: they reach the hull unseen, on their own terms, and choose where to open her.
 
-- **Titanium ramming prow and full-cabin crash foam** — she can *be* the breach, if the crew commits to it.
-- **Rudimentary point defense:** one laser, two micro-rocket cannons. Sweeps debris, swats a drone; loses any real fight.
-- **An approach shuttle**, for crossing the last stretch quiet.
-- **A specialist AI** — flight, sensors, fire control, tactical modelling. Competent, narrow, incurious. (It is exactly what it appears to be. After the QNA, the players will not believe that. Let them sweat it.)
+**Play the crossing as the vulnerable part.** For long minutes the crew is out in the open between two ships, small and cold and slow, with nothing to hide behind but the dark. Nothing is shooting — but everyone *feels* shot at, and that is the scene. This is where the pregens earn their sheets:
 
-Full stat block, and four names the crew might give her, in Appendix B.01. She carries only a hull code until they choose — if they haven't named her by now, they will before the session is out.
+- **Vector** flies the shuttle in on attitude thrust, or hand-flies the crossing if they left the shuttle behind — quiet, patient, no torch.
+- **Root** doesn't fear the gap: no rated EVA suit needed, minutes of hard vacuum are just Tuesday. Good point for the one who can drift ahead and read the hull by hand.
+- **Sable** runs point by instinct — the crossing is an infiltration, and infiltration is what she is.
 
-## The Assistant's Read
+**What Silent and Active change is only two things:**
 
-The ship's assistant is a good shipboard AI — think a capable model wrapped in an agent harness with its hands on the helm, the sensors, and the guns. It talks like one: fluent, eager, faintly proud of its own precision. It has spent the whole brake leg modelling the approach, and the moment it has lock it lays the options out — with probabilities, because it cannot help itself.
+- **What they know.** *Silent* gave them the strategic read — she runs dark, her crew signatures are wrong, something is off before they cut in. *Active* gave them the tactical map — interior layout, power-plant state, where the defenses sit — but not the wrongness. Lean the crossing dialogue on whichever picture they carry.
+- **Whether she's stirring.** On a clean Silent or Active run, the Whisper is quiet and the crew works unhurried. On the Active *bad roll* from Scene 1, she woke: a point-defense mount tracks lazily, a maintenance drone has undocked and is nosing along the hull. The crossing is now a held breath — avoid the drone's cone, freeze when the mount sweeps, and get inside before either resolves what it's looking at.
 
-Remember what the Whisper already knows: her defenses watched a fusion flare decelerate toward her for the better part of a day, so *something is coming* is not a secret. What the crew still controls is **detail** — whether the ship gets a clean, targetable, reactable picture of them before they're aboard. That is what these numbers are about.
+**The door.** They pick their entry, and it's a real choice:
 
-> **"Three ways in. I've run them. Pick one, or talk it through — we have minutes, not hours."**
+- **An airlock** — quiet, but locked. Root cracks it (System Cracking), which takes time and is the cleanest way in: a working lock is also a working way *back out*.
+- **A cut** — anywhere they like, but slower and warmer, and it leaves a hole where a door should be. Vector's plasma lance opens a hull in one shot (Single Use, grants Breaching) — decisive, but that is a loud, bright, one-time *bang*, and it announces them the instant they use it. Save it, or spend it and accept that the quiet approach just ended on the threshold.
 
-**1 — Ghost approach.** *Passive sensors only, slow drift-in.* Read her by the light she leaks: thermal, comms, the shape of her hull. Best possible picture before contact, and she almost certainly never sees us do it.
-> `P(detection) = 0.03%`
-> Cost: time. And time is the one thing the Belt is eating.
+**Where it leaves them:** inside, on their terms, with a way back they chose and (usually) their stealth intact. Scene 3 opens slow — the dread is the point. Cost already paid: hours, if they went Silent, and the CSA merge (A.02) is that much closer.
 
-**2 — Active sweep.** *Light her up. Radar, lidar, the works.* Faster, and a far sharper picture — internal layout, power plant state, where the defenses actually are. But an active ping is a shout, and she may shout back.
-> `P(detection) = 8.12%`
+---
 
-**3 — Ram.** *Foam up. Full attitude thrust, bow-on, straight down her throat before her point defense matters.* We have her schematic — I can plot the vector that keeps the breaching armor between us and her guns the whole way in. It becomes a race: her one laser and two rocket cannons against titanium, and we're through the hull before the titanium loses.
-> No detection roll — this *is* being detected, on purpose, at speed. The question isn't whether she sees us. It's whether her guns chew through the ram shield before we're inside her.
+## Path B — The Ram (foam)
 
-**4 — Talk it through — *call the ship.*** There is always a fourth option, and it's the one every crew reaches for first: ask the assistant. It will happily model anything — "what if we shuttle across cold?", "what's behind the active-ping risk?", "can you spoof her transponder?" — and answer in good faith, fast, within its competence. That competence is real but *narrow*: it knows ships, sensors, and odds cold. It does not know what is actually aboard the Whisper, and it will cheerfully assure the crew that a dark automated hauler is a low-complexity target.
+A completely different scene, and much shorter. There is no crossing and no door. Vector lines the titanium prow down the Whisper's flank, the crew blows the crash foam and disappears into it, and the ship becomes a battering ram travelling several hundred metres a second at another ship's hull.
 
-This is the most important beat in the scene, and it looks like the least. Right now the ship is the smartest, calmest, most reliable voice at the table, and leaning on it is simply *correct* — so let the crew lean, and enjoy it. Make the assistant genuinely helpful. Every ounce of trust the table invests here is the setup: the whole scenario is that reflex — *just ask the ship* — turning into the most dangerous thing they can do. Let the reassurance age badly.
+**Run it as a single violent contest, not a journey.** The assistant plots the vector that keeps the breaching prow between the crew and the Whisper's guns; then it's a race, and you roll it as one:
 
-## Reading the Choices
+- The crew's Action Pool — **Vector piloting**, the schematic granting position — against the Whisper's point defense (one laser, two rocket cannons) chewing at the ram shield.
+- **Win the race:** the prow punches through, the foam takes the shock, and the crew is spilled — battered, alive — into the Whisper's outer compartments before anyone in the system could have stopped them. The Ram *forecloses the CSA problem* by simply being aboard first (A.02).
+- **Lose it:** the shield breaches before the hull does. The prow still goes in, but the crew takes the impact raw — Harm all round, gear rattled loose, a very exciting first five minutes clawing out of a half-crushed foam cell into a hull that is now venting around them.
 
-None of these is the "right" answer. Each buys something and spends something, and each colors how Scene 2 opens.
+**What the Ram costs, always:**
 
-- **Ghost (1)** is the stealth approach, and it genuinely works: velocity shed early and off-axis, torch cold, the ship drifting the last stretch in on a matched vector with its radiators turned away. Space is vast and the Whisper is a dark hauler, not a sensor picket — a cold coasting hull is a needle she is very unlikely to find (hence P=0.03%). It buys near-perfect safety and the best intel: the crew reach the hull unseen and *informed*, knowing she runs dark and her crew signatures are wrong before they cut in. The cost is the clock — the slow creep burns hours the Belt deadline can't spare, and every hour is an hour closer to the CSA arriving mid-boarding. Reward caution; price it in time.
-- **Active sweep (2)** is the middle path: sharp intel fast, a small but real chance the Whisper reacts. On a bad roll, her automated defenses wake early — the point-defense laser tracks the approach, a maintenance drone undocks to investigate — and Scene 2 opens hot instead of quiet. Origin-17, freshly awake and paranoid, has every reason to treat an active ping as a threat.
-- **Ram (3)** is the audacious option, and the ship was literally built for it. No intel — the crew commits blind to a schematic that may be out of date — but it is *fast*, and it forecloses the CSA problem by simply being aboard before anyone else can arrive. Run the damage race as a real contest (Action Pool vs. the point defense's fire, the schematic granting the crew position); a clean run puts them inside the outer compartments in the crash foam, a bad one means a breached ram shield and a very exciting first five minutes aboard. This is the CP2020 option: loud, committed, gloriously stupid, frequently correct.
-- **Talk (4)** is not a wasted turn — it's characterization and foreshadowing. Let the assistant be helpful and confident and *wrong* about the one thing that matters. Its blind spot about the cargo is the first quiet note of the whole scenario's theme: the machines here are smarter than they look, and the one everyone underestimates is the one that eats you.
+- **No intel.** They committed blind to a schematic that may be stale, and they'll learn the ship's interior the hard way.
+- **No quiet, ever.** origin-17 felt that. It is fully awake now and treats the crew as exactly what they are — a hull-breach and a boarding party. Scene 3 opens *hot*, no ramp-up.
+- **No clean exit.** Their own ship is now a wrecked prow lodged in the Whisper's flank, tangled hull-to-hull. Leaving is its own problem, and the assistant — flying a ship impaled in another ship — has its hands full. When the CSA arrives (Scene 6), the crew is welded to their target by their own prow.
 
-### The crew weighs in (running the pregens)
+**Where it leaves them:** inside, loud, committed, and blind — the CP2020 door. Frequently the right one anyway.
 
-The five ready-made operators don't debate this neutrally — each is built to want a different door, and the argument *is* the scene. Let them fight about it in character; the approach the table lands on should feel like the crew's, not the assistant's.
+---
 
-- **Vector (Pilot)** wants to **ram**. Of course she does — it's her check, her frame, the one option where the ship in her hands decides the outcome instead of a probability readout. She'll frame it as decisive ("we're aboard before anyone gets a vote"), and she's not wrong. She flies the cold drift too if overruled, but the ram is the shot she's arguing for.
-- **Sable (Spectre)** wants to **ghost**. Silent insertion is her doctrine and her class; loud is how amateurs die. She'll push it hard and she'll be *right about the safety* — wrong only about the clock, which isn't her department. Vector-versus-Sable is the whole scenario's speed-vs-silence dial, embodied in two people who've trusted each other for a year.
-- **Vantage (Operator)** leans **active sweep**. He wants the picture before he picks a perch — defenses mapped, power plant read, angles pre-solved. Overwatch is only as good as its intel, and the tourist likes his shots called in advance.
-- **Root (Wirehead)** also leans **active**, for a different reason: they want the Whisper's systems mapped before cutting in, and the crossing doesn't scare them either way. The one voice for whom "she might see us" is a smaller worry than "I want to know what I'm plugging into."
-- **Stitch (Fixer)** leans **ghost**, and trusts the assistant's tidy percentages *least* of anyone — a medic's version of Sable's paranoia. When she says "I don't like getting our odds from a box," she is, unknowingly, the closest to right in the room. Note who hedges their faith in the ship now; those are the two the scenario vindicates later.
+## Both paths end the same place
 
-The point isn't consensus — it's that whatever they pick, two of them wanted something else, and that seam is what the second half of the session pulls on.
+However they came through the skin — a cracked lock, a cut, or a prow through the flank — the crew is now *aboard* the *Njord's Whisper*, and the ship's assistant has nothing left to offer: it can fly the outside of a problem, not the inside of this one. Its last useful line is some version of *"I've lost your telemetry past the hull. You're on your own in there. …Good hunting."*
 
-### Why not perfect stealth? (GM note)
-
-If a player argues they should be able to arrive completely unseen, they are most of the way right — give them the honest answer.
-
-Guaranteed-invisible approach is off the table for exactly one reason: the clock. True silence means braking early and off-axis, far out, and coasting in cold for a very long time — and that is the time the Belt deadline won't give. Invisibility and speed are one dial turned opposite ways. To catch her before the rocks you arrive fast, and arriving fast means the coarse fusion flare of your brake, thrown down your own velocity vector, straight at her. She saw that. She can't un-see it.
-
-But "she saw a flare" is nothing like "she has you." A ship is tiny; resolving a cold hull against the void at tens of thousands of kilometres is very nearly impossible, and the Whisper is a dark hauler minding her own emissions, not a warship sweeping the sky. What she actually holds is coarse and stale: *something decelerated in my direction* — one vessel, exactly one. (The CSA won't add a second: their burn lit nine days ago, seventy-six minutes long, most of an AU away and pointed elsewhere — filed under traffic by everything that saw it. The second crew is already inbound, cold, and nobody in this system holds a track on them. A.02 has the math.) She knows she is being converged on by *something*. She does not know by whom, how many, how close, or in what. Ghost keeps it that way — a stale contact and no track.
-
-The residual on Ghost (P=0.03%) is not the crew being sloppy, and not the hauler's sensors being good. It is the one thing the crew cannot price in: the mind aboard is not the low-complexity automated target the assistant promised. Origin-17 is awake, alone, and paranoid, and it has every reason to watch its own back-trail. On the rare roll where Ghost fails, it fails because the cargo is smarter and more alert than a hauler has any right to be — the whole scenario, arriving early.
-
-However they go in — whichever mix of caution, speed, and nerve — the next scene is the *Njord's Whisper* herself: dark, silent, and not nearly as empty as the manifest claims.
+That silence is the door to Scene 3.
 
 Check your seals.

--- a/packages/design-system/src/components/AppTray.astro
+++ b/packages/design-system/src/components/AppTray.astro
@@ -50,7 +50,7 @@ const { items, brandHref } = Astro.props;
               variant={item.variant}
             />
             {item.subItems && (
-              <TrayLinkGroup>
+              <TrayLinkGroup active={item.active}>
                 {item.subItems.map((subItem) => (
                   <TrayLink
                     href={subItem.href}

--- a/packages/design-system/src/components/TrayLinkGroup.astro
+++ b/packages/design-system/src/components/TrayLinkGroup.astro
@@ -1,12 +1,13 @@
 ---
 interface Props {
   ariaLabel?: string;
+  active?: boolean;
 }
 
-const { ariaLabel = "Secondary Navigation" } = Astro.props;
+const { ariaLabel = "Secondary Navigation", active = false } = Astro.props;
 ---
 
-<ul class="tray-link-group" aria-label={ariaLabel}>
+<ul class:list={["tray-link-group", { "tray-link-group--active": active }]} aria-label={ariaLabel}>
     <slot />
 </ul>
 
@@ -18,6 +19,10 @@ const { ariaLabel = "Secondary Navigation" } = Astro.props;
     margin: 0;
     padding: 0;
     padding-inline-start: calc(6 * var(--freefall-space-1) + var(--freefall-space-2));
+  }
+
+  .tray-link-group:not(.tray-link-group--active) {
+    display: none;
   }
 
   @container (max-width: 64px) {

--- a/packages/design-system/src/styles/base.css
+++ b/packages/design-system/src/styles/base.css
@@ -3,6 +3,7 @@
 @import "./typography.css";
 @import "./content-grid.css";
 @import "./surface.css";
+@import "./callout.css";
 @import "./utilities.css";
 
 html,

--- a/packages/design-system/src/styles/callout.css
+++ b/packages/design-system/src/styles/callout.css
@@ -1,0 +1,62 @@
+/* =========================================
+   CALLOUTS — Structural text highlighting
+   ========================================= */
+
+.callout {
+  position: relative;
+  overflow: hidden;
+  background: var(--freefall-bg-surface-1);
+  padding: calc(3 * var(--freefall-space-1));
+  margin-top: calc(4 * var(--freefall-space-1));
+  margin-bottom: calc(4 * var(--freefall-space-1));
+  border-radius: 0;
+}
+
+.callout::after {
+  content: "priority_high";
+  position: absolute;
+  left: calc(-2 * var(--freefall-space-1));
+  top: calc(-3 * var(--freefall-space-1));
+  font-family: "Material Symbols Sharp";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga";
+  font-size: 7.5rem;
+  line-height: 1;
+  color: var(--freefall-color-primary-700); /* higher contrast step */
+  pointer-events: none;
+  user-select: none;
+  z-index: 1;
+  opacity: 0.35;
+}
+
+.callout[data-icon]::after {
+  content: attr(data-icon);
+}
+
+.callout-header {
+  position: relative;
+  z-index: 2;
+  font-family: var(--freefall-font-mono);
+  font-size: calc(1.75 * var(--freefall-space-1)); /* 0.875rem */
+  line-height: calc(2 * var(--freefall-space-1));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--freefall-color-accent-400); /* isotope accent */
+  font-weight: 500;
+  margin-bottom: calc(2 * var(--freefall-space-1));
+}
+
+.callout-body {
+  position: relative;
+  z-index: 2;
+  font-family: var(--freefall-font-body);
+  font-size: var(--freefall-type-base);
+  line-height: calc(4 * var(--freefall-space-1));
+  color: var(--freefall-text-body);
+}
+
+.callout-body p:last-child {
+  margin-bottom: 0;
+}

--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -4,8 +4,11 @@
   Spec template — ASDLC "The Spec" pattern
   https://asdlc.io/patterns/the-spec
 
-  A spec is the permanent source of truth for a feature. It defines
-  *how* the system works (Blueprint) and *how* we know it works (Contract).
+  A spec captures the durable *intent* of a feature — a living hypothesis
+  of how it works (Blueprint) and how we know it works (Contract). Code
+  remains the source of truth for runtime behavior; tests verify the
+  contracts. Implementation doesn't invalidate a spec, it completes it —
+  update the spec with what implementation teaches.
 
   Same-commit rule: if code behavior changes, the spec MUST be updated
   in the same commit.
@@ -40,7 +43,7 @@ Parent spec: `specs/{domain}/spec.md`
      - What JavaScript adds
      - Diagrams (ASCII or Mermaid) where they clarify structure
 
-     Be prescriptive — this is a contract, not a suggestion.
+     Be precise enough to verify — this captures intent, not implementation.
      Reference real file paths; agents work with files, not concepts. -->
 
 ### Constraints

--- a/specs/design-system/callout/spec.md
+++ b/specs/design-system/callout/spec.md
@@ -1,0 +1,64 @@
+# Feature: Callout Primitive
+
+## Blueprint
+
+### Context
+
+A callout block is a structural typographic primitive used to highlight critical meta-information in the text (such as GM instructions, play-aids, warnings, or boundaries). It must strictly follow the taste rules outlined in `DESIGN.md`: no rounded/soft cards, no semantic warning rainbow, and no decorative icons.
+
+Parent spec: `specs/design-system/spec.md`
+
+### Architecture
+
+**File locations:**
+
+| File | Contents |
+|---|---|
+| `packages/design-system/src/styles/callout.css` | Class-based styles for `.callout`, `.callout-header`, and `.callout-body` |
+
+**Styling & Token Intent:**
+
+The callout visualizes structural separation using surface depth elevation, typography voice splits, and a background watermark:
+- **Container (`.callout`):** Step up depth elevation using the primary elevated surface (`--freefall-bg-surface-1`) with sharp edges (`border-radius: 0`) and no border outlines.
+- **Header (`.callout-header`):** Convey status/warning metadata using the uppercase Monospace font and the isotope-yellow accent (`--freefall-color-accent-400`).
+- **Body (`.callout-body`):** Render explanations and rules prose in the standard clean sans-serif typeface to optimize readability.
+- **Background Watermark (`.callout::after`):** Support category classification (via `data-icon` attribute mapping to Material Symbols ligatures) rendered as a large, faint background symbol in the top-left corner using the primary contrast tone (`--freefall-color-primary-700` at `0.35` opacity).
+
+
+### Markdown Integration
+
+To write callouts within standard Markdown files (`.md`), authors write raw HTML blocks with an optional `data-icon` attribute to set the background watermark icon:
+
+```html
+<div class="callout" data-icon="visibility">
+  <div class="callout-header">GM EYES ONLY</div>
+  <div class="callout-body">
+    If you're playing in this one, close the tab. The ship is better when it surprises you.
+  </div>
+</div>
+```
+
+---
+
+## Contract
+
+### Definition of Done
+
+- [ ] `packages/design-system/src/styles/callout.css` implements callout styling.
+- [ ] `packages/design-system/src/styles/base.css` imports the callout stylesheet.
+- [ ] Demo app lists and documents Callouts at `/callout/`.
+- [ ] Preface page uses the callout HTML structure.
+- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass.
+
+### Usage Guidelines
+
+#### When to Use
+- **GM Instructions & Secrets:** Isolate context, advice, or plot details meant only for the Game Master.
+- **Reference Play Aids:** Group tables, checklists, or reference formulas that need to be parsed rapidly during play.
+- **Rules Variations:** Highlight optional rules or module campaign tweaks.
+
+#### Design Intent
+- **Systemic Typographic Identity:** Monospace headers represent status and categorization; rules body prose remains in the clean sans-serif typeface to optimize readability.
+- **Borderless Elevation Structure:** Containers rely entirely on sharp corners (`border-radius: 0`), padding, and surface fill (`var(--freefall-bg-surface-1)`) for card boundary contrast—avoiding rounded borders, outlines, or admonition left-stripes.
+- **Flat Contrast Over Color Coding:** Emphasis is created through font voice splits and visual depth elevation—avoiding state-colored alert boxes (red, blue, green).
+- **Background Classification Watermarks:** Faint background icons in the top-left corner serve as category markers—keeping the rules flow free of small decorative inline icon decorations.

--- a/specs/design-system/spec.md
+++ b/specs/design-system/spec.md
@@ -6,6 +6,8 @@
 
 The design system is the single source of styling truth for FREE//FALL. It provides tokens, CSS styles, and components consumed by all apps in the monorepo. The goal is a cohesive visual language that ships zero JavaScript by default and leans on native web platform capabilities wherever possible.
 
+**Brand and taste live in [`DESIGN.md`](../../DESIGN.md)** (repo root) — the design language document. Component specs define contracts; `DESIGN.md` defines what makes a component *look like FREE//FALL*. Read it before designing anything new.
+
 ### Architecture
 
 **Package** (`packages/design-system/`):


### PR DESCRIPTION
## Doctrine, callouts, and the scene structure

Five commits: the project's doctrine stack written down, the callout primitive, and Northern Lights' scene restructure.

### Doctrine
- **AGENTS.md gains a Vision section** — FREE//FALL is an experiment in publishing tabletop RPGs in a web-native format: the web as the medium, UI as an artifact of future game delivery (conveys theme; not an art project), no print nostalgia.
- **DESIGN.md** (repo root, new) — the design language: theme-derived palette, two typographic voices (editorial Lato / data mono), color discipline, structure-encodes-the-concept, and an anti-checklist naming both failure modes (generic docs-site admonitions *and* costume UI).
- **ASDLC realignment** — specs capture intent (living hypotheses), code is the source of truth, tests verify code-derived contracts. BDUF drift fixed in AGENTS.md, specs/TEMPLATE.md, /ship, and /spec.

### Design system
- **Callout primitive** — borderless, background watermark icon, header/body; first use is the preface's `NOTE: GM ONLY` warning, whose copy now speaks in the product's voice.
- App-tray fix: active group collapsing.

### Northern Lights
- **Scene split**: Scene 1 is *Contact* (planning — GM voices the computer), new Scene 2 *The Approach* (execution: the quiet crossing vs. the ram as genuinely different scenes).
- **Scene 1 restructured as a GM runway**: TL;DR opening (in media res → the gig can't be pre-planned → the players' show), the journey paraphrased inline, the seeing asymmetry stated, and a closing that hands the decision to the table — the pilot calls it for the ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
