### PR TITLE
Design system contract boundaries

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,7 +60,7 @@ here. Keep it that way.
 
 ## Structure and hardware
 
-- **The grid is 0.5rem and non-negotiable.** Every dimension is `calc(N * var(--freefall-space-1))`. No raw px, no raw rem.
+- **The grid is 0.5rem and non-negotiable.** Production dimensions derive from spacing tokens. The narrow literal-length exceptions are the ones documented in the design-token contract: CSS query conditions, deliberately circular or pill-shaped radii, and standard visually-hidden one-pixel geometry.
 - **Sharp, not soft.** Icons are Material Symbols *Sharp*. Corners are square or barely eased; the one deliberate exception is the pill-shaped tray button (M3 heritage). Do not introduce friendly rounded cards.
 - **Structure encodes the concept.** The best existing components work because their structure *is* their meaning — and the meaning is a *delivery* idea, not a prop: the gear card works because gear is **queryable data** with its bindings and qualities exposed as fields; the term registry works because rules are **hypertext**; the scenario rail works because navigation is a **play aid**. When designing something new, ask: *what game concept does this deliver, and what does the web let it be that paper couldn't?* Design that — not a book feature, and not a movie prop.
 

--- a/apps/design-system/e2e/stat-circle.test.ts
+++ b/apps/design-system/e2e/stat-circle.test.ts
@@ -80,7 +80,7 @@ test.describe("StatCircle demo page", () => {
     test("value=null renders empty-set symbol", async ({ page }) => {
       const section = page
         .locator(".demo-section")
-        .filter({ hasText: "Disabled / Null" });
+        .filter({ hasText: "Void / Disabled" });
       const nullRow = section
         .locator(".circle-row")
         .filter({ hasText: "value=null" });
@@ -94,7 +94,7 @@ test.describe("StatCircle demo page", () => {
     test("value=null uses disabled class", async ({ page }) => {
       const section = page
         .locator(".demo-section")
-        .filter({ hasText: "Disabled / Null" });
+        .filter({ hasText: "Void / Disabled" });
       const nullRow = section
         .locator(".circle-row")
         .filter({ hasText: "value=null" });
@@ -105,7 +105,7 @@ test.describe("StatCircle demo page", () => {
     test("explicit disabled renders empty-set symbol", async ({ page }) => {
       const section = page
         .locator(".demo-section")
-        .filter({ hasText: "Disabled / Null" });
+        .filter({ hasText: "Void / Disabled" });
       const disabledRow = section
         .locator(".circle-row")
         .filter({
@@ -123,7 +123,7 @@ test.describe("StatCircle demo page", () => {
     test("value=0 is NOT disabled", async ({ page }) => {
       const section = page
         .locator(".demo-section")
-        .filter({ hasText: "Disabled / Null" });
+        .filter({ hasText: "Void / Disabled" });
       const zeroRow = section
         .locator(".circle-row")
         .filter({ hasText: "value=0" });
@@ -136,7 +136,7 @@ test.describe("StatCircle demo page", () => {
     test("value=0 uses type class, not disabled", async ({ page }) => {
       const section = page
         .locator(".demo-section")
-        .filter({ hasText: "Disabled / Null" });
+        .filter({ hasText: "Void / Disabled" });
       const zeroRow = section
         .locator(".circle-row")
         .filter({ hasText: "value=0" });

--- a/apps/design-system/e2e/tray-link-group.test.ts
+++ b/apps/design-system/e2e/tray-link-group.test.ts
@@ -8,9 +8,7 @@ test.describe("TrayLinkGroup Component", () => {
     await page.waitForLoadState("networkidle");
 
     // The open state container
-    const openContainer = page.locator(
-      '.demo-container[data-tray-state="open"]',
-    );
+    const openContainer = page.locator(".demo-container--open");
     const group = openContainer.locator(".tray-link-group");
     const links = group.locator(".tray-link");
 
@@ -44,9 +42,7 @@ test.describe("TrayLinkGroup Component", () => {
     await page.goto("/tray-link-group/");
     await page.waitForLoadState("networkidle");
 
-    const minimizedContainer = page.locator(
-      '.demo-container[data-tray-state="minimized"]',
-    );
+    const minimizedContainer = page.locator(".demo-container--minimized");
     const group = minimizedContainer.locator(".tray-link-group");
     const firstLink = group.locator(".tray-link").first();
 
@@ -71,9 +67,7 @@ test.describe("TrayLinkGroup Component", () => {
     await page.goto("/tray-link-group/");
     await page.waitForLoadState("networkidle");
 
-    const openContainer = page.locator(
-      '.demo-container[data-tray-state="open"]',
-    );
+    const openContainer = page.locator(".demo-container--open");
     // The last link has a very long label
     const longLink = openContainer.locator(".tray-link").last();
     const label = longLink.locator(".label");

--- a/apps/design-system/src/layouts/BaseLayout.astro
+++ b/apps/design-system/src/layouts/BaseLayout.astro
@@ -110,8 +110,9 @@ const navItems = Astro.props.navItems ?? [
   {
     icon: "web_asset",
     label: "App Shell",
-    href: "/app-bar/",
+    href: "/app-shell/",
     active: [
+      "/app-shell",
       "/app-bar",
       "/app-tray",
       "/drawer-brand",
@@ -120,6 +121,11 @@ const navItems = Astro.props.navItems ?? [
       "/tray-link-group",
     ].some((path) => Astro.url.pathname.startsWith(path)),
     subItems: [
+      {
+        label: "App Shell",
+        href: "/app-shell/",
+        active: Astro.url.pathname.startsWith("/app-shell"),
+      },
       {
         label: "App Bar",
         href: "/app-bar/",

--- a/apps/design-system/src/pages/app-bar.astro
+++ b/apps/design-system/src/pages/app-bar.astro
@@ -42,9 +42,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
   <h1>App Bar</h1>
   <p>
-    M3-style top app bar. Transparent background, 80px left margin to clear the
-    navigation rail / hamburger button. Accepts a <code>title</code> prop and a default
-    slot for trailing actions pushed to the right.
+    M3-style top app bar. Transparent background, with 64px mobile clearance
+    for the hamburger button and zero left margin at tablet sizes and above.
+    Accepts a <code>title</code> prop and a default slot for trailing actions pushed
+    to the right.
   </p>
 
   <div class="demo-section">
@@ -121,11 +122,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         >
         <td
           style="padding: var(--freefall-space-1) var(--freefall-space-2); border-bottom: calc(var(--freefall-space-1) / 4) solid var(--freefall-border-subtle);"
-          >calc(10 * var(--freefall-space-1))</td
+          >calc(8 * var(--freefall-space-1)) mobile; 0 tablet+</td
         >
         <td
           style="padding: var(--freefall-space-1) var(--freefall-space-2); border-bottom: calc(var(--freefall-space-1) / 4) solid var(--freefall-border-subtle);"
-          >80px</td
+          >64px mobile; 0 tablet+</td
         >
       </tr>
       <tr>

--- a/apps/design-system/src/pages/app-shell.astro
+++ b/apps/design-system/src/pages/app-shell.astro
@@ -1,0 +1,42 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="App Shell — FREE//FALL Design System">
+  <h1>App Shell</h1>
+  <p>
+    The document scaffold used by this page: AppTray, AppBar, and a single
+    scrollable <code>&lt;main&gt;</code> region.
+  </p>
+
+  <h2>Ownership</h2>
+  <dl>
+    <dt>AppShell</dt>
+    <dd>
+      Owns the document skeleton, viewport-bounded flex scaffold, vertical
+      scrolling, and the named <code>content</code> inline-size query container.
+    </dd>
+    <dt>Consumer content grid</dt>
+    <dd>
+      Owns content gutters, readable measure, columns, and breakout placement.
+      The wrapper around this page is supplied by the design-system docs layout,
+      not by AppShell.
+    </dd>
+  </dl>
+
+  <h2>Responsive Navigation</h2>
+  <p>
+    Mobile uses a modal drawer capped at 320px. Medium uses the existing rail
+    and overlay contract; overlay describes stacking and a scrim, not push
+    behavior. Desktop opens the tray in flex flow and pushes the app region.
+  </p>
+
+  <section class="surface border">
+    <h2>Global Primitives</h2>
+    <p class="p-1">
+      This direct content-grid item demonstrates the elevated
+      <code>.surface</code> contract together with the documented
+      <code>.border</code> and spacing utilities.
+    </p>
+  </section>
+</BaseLayout>

--- a/apps/design-system/src/pages/app-tray.astro
+++ b/apps/design-system/src/pages/app-tray.astro
@@ -41,7 +41,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <tr><th>Viewport</th><th>Closed</th><th>Open</th></tr>
     <tr>
       <td>Small (&lt; 620px)</td><td>Hidden</td>
-      <td>Full-screen overlay</td>
+      <td>320px capped modal drawer</td>
     </tr>
     <tr><td>Medium (620–779px)</td><td>Rail</td><td>Overlay drawer</td></tr>
     <tr><td>Large (≥ 780px)</td><td>Rail</td><td>Push drawer</td></tr>
@@ -96,7 +96,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   </ul>
 
   <p class="token-info">
-    Transitions: slide 200ms ease-out (open) / 150ms ease-in (close) · crossfade
-    150ms
+    Transitions: drawer slide 200ms ease-out (open) / 150ms ease-in (close).
+    The hamburger's three bars morph into a sharp cross.
   </p>
 </BaseLayout>

--- a/apps/design-system/src/pages/callout.astro
+++ b/apps/design-system/src/pages/callout.astro
@@ -46,7 +46,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <section style="margin-bottom: 4rem;">
       <h2 class="text-section" style="margin-bottom: 1.5rem;">Guidelines for Authors & Designers</h2>
       
-      <div class="freefall-prose">
+      <div>
         <h3>When to Use Callouts</h3>
         <p>
           Callouts should be used selectively by rules and fiction authors to highlight information that exists outside the main reading flow:

--- a/apps/design-system/src/pages/content-grid.astro
+++ b/apps/design-system/src/pages/content-grid.astro
@@ -3,15 +3,15 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout title="Content Grid">
-  <div class="content-grid">
     <h1 class="text-chapter" style="margin-bottom: var(--freefall-space-4);">
       Content Grid
     </h1>
 
     <p style="margin-bottom: var(--freefall-space-2);">
       Three-tier responsive grid driven by container queries on
-      <code>.app-shell__content</code>. Resize the browser or toggle the nav
-      tray to see tier transitions.
+      <code>AppShell</code>'s <code>main</code> element. This page itself is the
+      live fixture: resize the browser or toggle the nav tray to see whichever
+      responsive tier the available width supports.
     </p>
 
     <!-- Main column content -->
@@ -20,7 +20,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         Main Column (default)
       </h2>
       <div
-        class="freefall-prose"
         style="padding: var(--freefall-space-2); background: var(--freefall-bg-surface-1); border-radius: 4px;"
       >
         <p>
@@ -35,6 +34,20 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           equal and opposite reaction.
         </p>
       </div>
+    </section>
+
+    <section class="breakout" style="margin-bottom: var(--freefall-space-4);">
+      <h2 class="text-section" style="margin-bottom: var(--freefall-space-2);">
+        .breakout (spans main + side)
+      </h2>
+      <p
+        style="padding: var(--freefall-space-2); background: var(--freefall-bg-surface-1);"
+      >
+        Breakout content stays in the main column at the base tier and spans
+        through the side column at two-column tiers. Unlike
+        <code>.content-wide</code>, it does not opt into horizontal overflow
+        containment.
+      </p>
     </section>
 
     <!-- Side column content -->
@@ -141,6 +154,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <p style="margin: 0;">
           <strong>.content-wide</strong> → grid-column: main-start / side-end
         </p>
+        <p style="margin: 0;">
+          <strong>.breakout</strong> → main at base; main-start / side-end at
+          two-column tiers
+        </p>
       </div>
     </section>
 
@@ -159,5 +176,4 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         elements on the same page. Each one independently targets the side column.
       </p>
     </aside>
-  </div>
 </BaseLayout>

--- a/apps/design-system/src/pages/drawer-brand.astro
+++ b/apps/design-system/src/pages/drawer-brand.astro
@@ -11,11 +11,12 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       }
       .demo-container {
         container-type: inline-size;
+        box-sizing: content-box;
         border: calc(var(--freefall-space-1) / 4) dashed white;
         padding: 0;
       }
       .demo-container--rail {
-        width: calc(10 * var(--freefall-space-1));
+        width: calc(8 * var(--freefall-space-1));
       }
       .demo-container--open {
         width: calc(40 * var(--freefall-space-1));
@@ -51,7 +52,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <div class="demo-section">
     <h2>Rail State</h2>
     <p class="demo-label">
-      container width: calc(10 * var(--freefall-space-1)) · 80px
+       query container width: calc(8 * var(--freefall-space-1)) · 64px
     </p>
     <div class="demo-container demo-container--rail">
       <DrawerBrandDemo href="/drawer-brand/" />

--- a/apps/design-system/src/pages/gear-card.astro
+++ b/apps/design-system/src/pages/gear-card.astro
@@ -42,8 +42,24 @@ const sampleUtility = {
 
 const sampleVehicle = {
   category: "vehicle" as const,
+  title: "Needle Courier",
+  nickname: "Fast interorbital shuttle",
+  qualities: [
+    "Movement System (Fusion Torch)",
+    "Cargo (Light)",
+    "Life Support",
+  ],
+  frame: 12,
+  systems: 10,
+  pilot_binding: { body: 0, mind: 2, ghost: 0 },
+  vehicle_av: 2,
+  size_category: "Medium" as const,
+};
+
+const sampleExo = {
+  category: "exo" as const,
   title: "Hardshell Combat Exo",
-  nickname: "Heavy combat exo",
+  nickname: "Heavy combat exoskeleton",
   qualities: [
     "Movement System (EVA Thrusters, Walker Legs)",
     "Hardpoints (2 Assault, 1 Support)",
@@ -130,13 +146,15 @@ const sampleNoBinding = {
   <div class="demo-section">
     <h2>All Categories</h2>
     <p class="demo-label">
-      One card per gear category: weapon, armor, augmentation, utility, vehicle
+       One card per gear category: weapon, armor, augmentation, utility, exo,
+       vehicle
     </p>
     <div class="card-grid">
       <GearCardDemo data={sampleWeapon} body={1} />
       <GearCardDemo data={sampleArmor} body={1} />
       <GearCardDemo data={sampleAugmentation} ghost={3} />
       <GearCardDemo data={sampleUtility} ghost={2} />
+      <GearCardDemo data={sampleExo} />
       <GearCardDemo data={sampleVehicle} />
     </div>
   </div>

--- a/apps/design-system/src/pages/hamburger-button.astro
+++ b/apps/design-system/src/pages/hamburger-button.astro
@@ -6,8 +6,9 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 <BaseLayout title="Hamburger Button — FREE//FALL Design System">
     <h1>Hamburger Button (CSS Skew Variant)</h1>
     <p>
-        An interactive toggle button managing its animated state purely via CSS
-        Checkbox hacks. Zero Javascript is required. It utilizes <code
+        An interactive toggle whose pointer state and animation work without
+        JavaScript. Progressive enhancement adds keyboard button behavior and
+        synchronized expanded state. It utilizes <code
             >skewY</code
         > instead of <code>rotate</code> to ensure vertical edges stay sharp and geometric.
     </p>

--- a/apps/design-system/src/pages/iconography.astro
+++ b/apps/design-system/src/pages/iconography.astro
@@ -83,7 +83,9 @@ const sizes = ["1rem", "1.5rem", "2rem", "3rem"];
 
   <h1>Iconography</h1>
   <p class="token-info">
-    Material Symbols Sharp — ligature-based, loaded via Google Fonts
+    Material Symbols Sharp — ligature-based, loaded via Google Fonts. Rendering
+    these icons adds no JavaScript; the surrounding app shell has its own
+    navigation enhancement script.
   </p>
 
   <h2>Sample Icons</h2>

--- a/apps/design-system/src/pages/stat-circle.astro
+++ b/apps/design-system/src/pages/stat-circle.astro
@@ -102,16 +102,17 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   </div>
 
   <div class="demo-section">
-    <h2>Disabled / Null</h2>
+    <h2>Void / Disabled</h2>
     <p class="demo-label">
-      disabled and value=null are equivalent — both render &#x2205; in cobalt
-      colors. value=0 is an explicit zero, shown with attribute color.
+      Both states render &#x2205; in neutral colors. A null value is void and hides
+      its label; explicit disabled preserves its label. value=0 is an explicit
+      zero shown with attribute color.
     </p>
     <div class="circle-row">
       <span class="circle-row-label">value=null</span>
-      <StatCircleDemo type="body" value={null} />
-      <StatCircleDemo type="mind" value={null} />
-      <StatCircleDemo type="ghost" value={null} />
+      <StatCircleDemo type="body" attribute="Body" value={null} />
+      <StatCircleDemo type="mind" attribute="Mind" value={null} />
+      <StatCircleDemo type="ghost" attribute="Ghost" value={null} />
     </div>
     <div class="circle-row">
       <span class="circle-row-label">disabled</span>
@@ -135,7 +136,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <div class="demo-section">
     <h2>Bound State</h2>
     <p class="demo-label">
-      Active binding — highlighted ring. Disabled circles cannot be bound.
+      Active binding uses a solid attribute fill and glow. Disabled circles
+      cannot be bound.
     </p>
     <div class="circle-row">
       <span class="circle-row-label">bound</span>

--- a/apps/design-system/src/pages/tokens.astro
+++ b/apps/design-system/src/pages/tokens.astro
@@ -68,6 +68,16 @@ const semanticTokens = [
     ref: "primary-200",
   },
   {
+    name: "--freefall-text-high",
+    role: "Explicit high-emphasis text",
+    ref: "primary-50",
+  },
+  {
+    name: "--freefall-text-link",
+    role: "Links and definition emphasis",
+    ref: "accent-500",
+  },
+  {
     name: "--freefall-border-subtle",
     role: "Dividers, low-contrast",
     ref: "primary-800",
@@ -235,6 +245,13 @@ const semanticTokens = [
 
   <h1>Design Tokens</h1>
 
+  <p>
+    This page covers every base palette and public semantic color token, plus
+    the text-shadow and spacing families. Typography and content dimensions are
+    demonstrated on their owning reference pages; responsive behavior exercises
+    the breakpoint and content-grid tokens.
+  </p>
+
   <h2>Primary Palette — Deep Space Cobalt</h2>
   <div class="swatch-grid">
     {
@@ -307,7 +324,7 @@ const semanticTokens = [
     }
   </div>
 
-  <h2>Semantic Tokens</h2>
+  <h2>Semantic Color Tokens</h2>
   <ul class="semantic-list">
     {
       semanticTokens.map((token) => (

--- a/apps/design-system/src/pages/tray-button.astro
+++ b/apps/design-system/src/pages/tray-button.astro
@@ -10,6 +10,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         margin-bottom: calc(4 * var(--freefall-space-1));
       }
       .demo-container {
+        container-type: inline-size;
+        box-sizing: content-box;
         border: calc(var(--freefall-space-1) / 4) dashed
           var(--freefall-border-subtle);
         border-radius: calc(var(--freefall-space-1));
@@ -17,7 +19,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         margin-top: var(--freefall-space-2);
       }
       .demo-container--minimized {
-        width: calc(10 * var(--freefall-space-1));
+        width: calc(8 * var(--freefall-space-1));
       }
       .demo-container--open {
         width: calc(40 * var(--freefall-space-1));
@@ -35,17 +37,16 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <p>
     An adaptive navigation button for the AppTray. Displays an icon and text
     label in the expanded state, and collapses to icon-only when its parent
-    container signals minimized state via
-    <code>data-tray-state="minimized"</code>. No JavaScript required — layout
-    adapts entirely through CSS.
+    query is 64px or narrower. No JavaScript or state attribute is required:
+    layout adapts entirely from the nearest inline-size query container.
   </p>
 
   <div class="demo-section">
     <h2>Open State</h2>
     <p class="demo-label">
-      data-tray-state="open" · width: calc(40 * var(--freefall-space-1))
+      query container width: calc(40 * var(--freefall-space-1))
     </p>
-    <div class="demo-container demo-container--open" data-tray-state="open">
+    <div class="demo-container demo-container--open">
       <TrayButtonDemo icon="home" label="Home" href="/" />
       <TrayButtonDemo icon="palette" label="Design Tokens" href="/tokens/" />
       <TrayButtonDemo
@@ -53,6 +54,12 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         label="Typography"
         href="/typography/"
         active
+      />
+      <TrayButtonDemo
+        icon="arrow_back"
+        label="Back to catalog"
+        href="/"
+        variant="uplink"
       />
       <TrayButtonDemo
         icon="emoji_symbols"
@@ -65,11 +72,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <div class="demo-section">
     <h2>Minimized State</h2>
     <p class="demo-label">
-      data-tray-state="minimized" · width: calc(10 * var(--freefall-space-1))
+      query container width: calc(8 * var(--freefall-space-1)) · 64px
     </p>
     <div
       class="demo-container demo-container--minimized"
-      data-tray-state="minimized"
     >
       <TrayButtonDemo icon="home" label="Home" href="/" />
       <TrayButtonDemo icon="palette" label="Design Tokens" href="/tokens/" />
@@ -95,7 +101,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     </p>
 
     <h3>Active / Selected</h3>
-    <div class="demo-container demo-container--open" data-tray-state="open">
+    <div class="demo-container demo-container--open">
       <TrayButtonDemo icon="home" label="Home (default)" href="/" />
       <TrayButtonDemo icon="home" label="Home (active)" href="/" active />
     </div>
@@ -106,7 +112,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <p class="demo-label">Label truncates with ellipsis when constrained.</p>
     <div
       class="demo-container"
-      data-tray-state="open"
       style={`width: calc(24 * var(--freefall-space-1));`}
     >
       <TrayButtonDemo

--- a/apps/design-system/src/pages/tray-link-group.astro
+++ b/apps/design-system/src/pages/tray-link-group.astro
@@ -49,8 +49,9 @@ const _mockLinks = [
     <p>
         Renders secondary nested navigation links underneath a primary Tray
         location. It leverages CSS container queries to hide in minimized rail
-        views, and expand iteratively in fully opened tray situations. No
-        JavaScript required.
+        views at a 64px query-container threshold. The group also requires its
+        <code>active</code> prop; inactive primary locations do not expose nested
+        links. No JavaScript or state attribute is required.
     </p>
 
     <div class="demo-section">
@@ -58,7 +59,7 @@ const _mockLinks = [
         <p class="demo-label">
             container width: calc(40 * var(--freefall-space-1))
         </p>
-        <div class="demo-container demo-container--open" data-tray-state="open">
+        <div class="demo-container demo-container--open">
             <TrayButton icon="menu_book" label="Core Rules" href="#" />
 
             <TrayLinkGroupDemo active={true}>
@@ -78,7 +79,6 @@ const _mockLinks = [
         </p>
         <div
             class="demo-container demo-container--minimized"
-            data-tray-state="minimized"
         >
             <TrayButton icon="menu_book" label="Core Rules" href="#" />
 

--- a/apps/design-system/src/pages/typography.astro
+++ b/apps/design-system/src/pages/typography.astro
@@ -7,6 +7,18 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <h1 class="text-chapter" style="margin-bottom: 2rem;">Typography System</h1>
 
     <section style="margin-bottom: 4rem;">
+      <h2 class="text-section" style="margin-bottom: 1rem;">Typefaces</h2>
+      <p style="font-family: var(--freefall-font-body);">
+        Lato carries editorial prose and product copy in weights 300, 400, 700,
+        and 900.
+      </p>
+      <p style="font-family: var(--freefall-font-mono);">
+        IBM Plex Mono carries structured data and system labels in weights 400
+        and 500.
+      </p>
+    </section>
+
+    <section style="margin-bottom: 4rem;">
       <h2 class="text-section" style="margin-bottom: 1rem;">
         Editorial Class Hierarchy
       </h2>
@@ -178,18 +190,17 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
     <section style="margin-bottom: 4rem;">
       <h2 class="text-section" style="margin-bottom: 1rem;">
-        .freefall-prose Scope Integration
+        Rich Text in main
       </h2>
       <div
-        class="freefall-prose"
         style="padding: 2rem; background: var(--freefall-bg-surface-1); border-radius: 4px;"
       >
         <!-- Simulating markdown output -->
         <h1 id="chapter">Chapter 1: The Void</h1>
         <p>
-          This is a standard paragraph showing body text within the prose scope.
-          Notice how it strictly adheres to a maximum layout measure of 65
-          characters to remain highly legible and comfortable to read.
+          This standard paragraph shows naked rich text under the document's
+          main scope. The surrounding content grid, not typography, owns the
+          67-character reading measure.
         </p>
 
         <h2 id="section">Mechanical Systems</h2>
@@ -197,7 +208,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
         <h3 id="subsection">Granular Rulings</h3>
         <ul>
-          <li>This is a list item inside a prose scope.</li>
+          <li>This is a list item inside the main rich-text scope.</li>
           <li>It should inherit proper line-height and tight indentation.</li>
         </ul>
 

--- a/docs/architecture/ADR-2026-03-11-design-system-component-model.md
+++ b/docs/architecture/ADR-2026-03-11-design-system-component-model.md
@@ -1,6 +1,6 @@
 # ADR-2026-03-11: Design System Component Model and CSS Architecture
 
-**Status:** Accepted (implemented 2026-03-11; status updated 2026-07-05)
+**Status:** Superseded by [ADR-2026-07-19](./ADR-2026-07-19-design-system-contract-boundaries.md)
 
 **Date:** 2026-03-11
 

--- a/docs/architecture/ADR-2026-07-19-design-system-contract-boundaries.md
+++ b/docs/architecture/ADR-2026-07-19-design-system-contract-boundaries.md
@@ -1,0 +1,138 @@
+# ADR-2026-07-19: Design System Contract Boundaries
+
+**Status:** Accepted
+
+**Date:** 2026-07-19
+
+**Supersedes:** [ADR-2026-03-11](./ADR-2026-03-11-design-system-component-model.md)
+
+## Context
+
+The March 2026 component-model ADR established source distribution, layered
+CSS, co-located component styles, CSS custom properties as tokens, and
+Astro-first components. Implementing and operating that model exposed several
+places where its prescribed boundaries did not match the system that proved
+useful in production:
+
+- `AppShell` became the shared document root and naturally owns foundation
+  loading for both applications.
+- Rich-text element styles are applied to the shell's `main` content region;
+  the content grid, not a prose wrapper, owns readable measure.
+- Callouts and a small set of utilities are global opt-in primitives, but are
+  neither foundation nor self-contained Astro components.
+- Scoped component styles retain some readable BEM-like class names. Those
+  names remain implementation details and do not require wrapper-only markup.
+- The surface primitive must target the direct placement contract used by the
+  content grid.
+- Accessible navigation uses small inline scripts for progressive enhancement
+  while retaining an HTML/CSS baseline. Avoiding a framework client runtime,
+  not avoiding all JavaScript, is the relevant constraint.
+
+The living contracts and current inventory belong in `specs/design-system/`
+and package source. This ADR records only the architectural decisions.
+
+## Decision
+
+### Retained Decisions
+
+The design system remains source-distributed with no independent package build
+step. Astro remains the default component format, component styles remain
+co-located, and typed props remain the public component API. CSS class names
+inside components remain implementation details. CSS custom properties remain
+the sole token source.
+
+### Foundation Ownership
+
+`AppShell` is the document root for consuming applications. It imports
+`base.css` once and renders `FontLinks` in the document head. Consumers using
+`AppShell` do not import or render those dependencies separately.
+
+Foundation consists of the reset, CSS custom-property tokens, typography, and
+document-level defaults. CSS custom properties are the sole token source; no
+parallel TypeScript token layer or barrel is maintained.
+
+### Global Primitives
+
+Global CSS may provide opt-in primitives when plain HTML and a documented class
+contract are more appropriate than an Astro component. This layer includes
+layout primitives such as `.content-grid` and `.surface`, structural content
+patterns such as `.callout`, and a deliberately small utility set.
+
+The surface placement contract is:
+
+```css
+main > .content-grid > .surface
+```
+
+This targets direct grid items without broad descendant leakage.
+
+### Rich Text And Measure
+
+`main` is the rich-text element scope. Naked headings, paragraphs, lists,
+tables, definition lists, blockquotes, `pre`, and `em` inside the content pane
+receive editorial defaults without a required prose wrapper class.
+
+`.content-grid` independently owns readable measure and responsive placement.
+Its main column is the sole prose-width constraint.
+
+### Component Encapsulation
+
+Astro components keep their styles co-located and expose behavior through
+typed props. Component class names are implementation details.
+
+Scoped styles may use readable BEM-like names when useful. Authors must not add
+DOM solely to satisfy a naming convention, couple parent layouts to a child's
+internal classes, or expose those classes as consumer API. Structural selectors
+remain preferred when they express the relationship without extra markup.
+
+### Progressive Enhancement
+
+Components prefer native HTML and CSS. Inline scripts may add keyboard
+semantics, focus management, and other progressive enhancements when the core
+interaction remains available without JavaScript. Framework islands require a
+separate demonstrated need; the default build contains no framework client
+runtime.
+
+### Dimensional Exceptions
+
+Ordinary production dimensions derive from design tokens. Literal lengths are
+permitted only where CSS cannot consume custom properties in query conditions,
+where a large radius encodes a circle or pill, or where a standard
+visually-hidden technique requires one-pixel geometry.
+
+## Consequences
+
+**Positive:**
+
+- Foundation dependencies have one owner across both applications.
+- Rich-text styling and page measure have separate, explicit responsibilities.
+- Global CSS patterns have an architectural home without forcing components.
+- Scoped class naming can optimize readability without becoming public API.
+- Progressive enhancement is evaluated by baseline capability and runtime
+  cost rather than a blanket script prohibition.
+
+**Negative:**
+
+- `AppShell` is intentionally coupled to the shared foundation entrypoint.
+- `main` scopes rich-text styles broadly within the content pane, so UI placed
+  there must use component styles to establish its own presentation.
+- The global primitive layer requires discipline to remain small and
+  documented.
+
+## Alternatives Considered
+
+### Continue Amending The March ADR
+
+Rejected. Rewriting an implemented ADR obscures the context and tradeoffs that
+produced the original decision. A superseding record preserves that history.
+
+### Restore A Required Prose Wrapper
+
+Rejected. Both applications already share a bounded `main` content region, and
+the content grid owns measure. A second wrapper would duplicate structure
+without adding a distinct runtime boundary.
+
+### Require Flat Class Names In Scoped Components
+
+Rejected. Astro already provides collision isolation. Naming shape does not
+create encapsulation; public contracts and consumer coupling do.

--- a/packages/design-system/src/components/AppShell.astro
+++ b/packages/design-system/src/components/AppShell.astro
@@ -9,6 +9,7 @@ interface NavItem {
   label: string;
   href: string;
   active?: boolean;
+  variant?: "nav" | "uplink";
   subItems?: {
     label: string;
     href: string;

--- a/packages/design-system/src/components/DrawerBrand.astro
+++ b/packages/design-system/src/components/DrawerBrand.astro
@@ -11,7 +11,7 @@ const { href = "/about" } = Astro.props;
 <a
   class="drawer-brand"
   href={href}
-  aria-label="Kustannusosakeyhtiö Myrrys — about"
+  aria-label="Kustannusosakeyhtiö Myrrys"
 >
   <span class="logo" set:html={myrrysLogoRaw} />
   <span class="drawer-brand__caption text-caption">
@@ -31,6 +31,20 @@ const { href = "/about" } = Astro.props;
     text-decoration: none;
     border-radius: calc(var(--freefall-space-1));
     transition: color 0.2s ease;
+  }
+
+  .drawer-brand:hover > .drawer-brand__caption {
+    color: var(--freefall-text-body);
+  }
+
+  .drawer-brand:focus-visible {
+    outline: calc(var(--freefall-space-1) / 4) solid
+      var(--freefall-action-base);
+    outline-offset: calc(var(--freefall-space-1) / 4);
+  }
+
+  .drawer-brand:focus-visible > .drawer-brand__caption {
+    color: var(--freefall-text-body);
   }
 
   .logo {

--- a/packages/design-system/src/components/GearCard.astro
+++ b/packages/design-system/src/components/GearCard.astro
@@ -82,6 +82,7 @@ const categoryIcon: Record<string, string> = {
   augmentation: "biotech",
   utility: "handyman",
   vehicle: "rocket_launch",
+  exo: "rocket_launch",
 };
 ---
 

--- a/packages/design-system/src/components/stat-circle.test.ts
+++ b/packages/design-system/src/components/stat-circle.test.ts
@@ -22,11 +22,11 @@ interface Props {
 
 function deriveState(props: Props) {
   const { type, attribute, value, disabled, bound } = props;
+  const isVoid = value === null && !disabled;
   const isDisabled = disabled || value === null;
   const isBound = !isDisabled && bound;
-  const displayLabel = attribute
-    ? attribute.slice(0, 5).toUpperCase()
-    : undefined;
+  const displayLabel =
+    attribute && !isVoid ? attribute.slice(0, 5).toUpperCase() : undefined;
   const displayValue = isDisabled ? "\u2205" : value;
 
   const circleClass = [
@@ -145,11 +145,21 @@ describe("StatCircle state derivation", () => {
       expect(s.displayLabel).toBe("GHOST");
     });
 
-    it("label renders even when disabled", () => {
+    it("void hides the label", () => {
       const s = deriveState({
         type: "body",
         attribute: "Body",
         value: null,
+      });
+      expect(s.displayLabel).toBeUndefined();
+    });
+
+    it("explicit disabled shows the label", () => {
+      const s = deriveState({
+        type: "body",
+        attribute: "Body",
+        value: 2,
+        disabled: true,
       });
       expect(s.displayLabel).toBe("BODY");
     });

--- a/specs/design-system/app-bar/spec.md
+++ b/specs/design-system/app-bar/spec.md
@@ -78,17 +78,17 @@ The AppShell renders `<AppBar title={title}>`. The top bar styles are co-located
 
 ### Definition of Done
 
-- [ ] `AppBar.astro` renders a `<header>` with title prop and default slot for trailing actions
-- [ ] Bar has transparent background, no border
-- [ ] Left margin is `calc(8 * var(--freefall-space-1))` (64px) on mobile and `0` on tablet+
-- [ ] Bar height is `calc(8 * var(--freefall-space-1))` (64px)
-- [ ] Default slot content is pushed to the right end of the bar via `margin-left: auto` on the slot container
-- [ ] Slot container is a flex row with `align-items: center` and `gap: var(--freefall-space-1)`
-- [ ] All dimensions use `calc()` with `--freefall-space-1` — no raw px/rem
-- [ ] `AppShell.astro` uses `AppBar` instead of inline header markup
-- [ ] Top bar styles are co-located in AppBar's scoped `<style>` block
-- [ ] Design system demo app has an `/app-bar/` page demonstrating the title prop and slotted actions
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] `AppBar.astro` renders a `<header>` with title prop and default slot for trailing actions
+- [x] Bar has transparent background and no border
+- [x] Left margin is `calc(8 * var(--freefall-space-1))` (64px) on mobile and `0` on tablet+
+- [x] Bar height is `calc(8 * var(--freefall-space-1))` (64px)
+- [x] Default slot content is pushed to the right end of the bar via `margin-left: auto` on the slot container
+- [x] Slot container is a flex row with `align-items: center` and `gap: var(--freefall-space-1)`
+- [x] Component dimensions derive from spacing tokens
+- [x] `AppShell.astro` uses `AppBar` instead of inline header markup
+- [x] Top bar styles are co-located in AppBar's scoped `<style>` block
+- [x] Design system demo app has an `/app-bar/` page demonstrating the title prop and slotted actions
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
 
 ### Regression Guardrails
 

--- a/specs/design-system/app-shell/spec.md
+++ b/specs/design-system/app-shell/spec.md
@@ -81,21 +81,17 @@ The scaffold has four regions:
 
 | Viewport | Navigation | Top bar | Content pane |
 |---|---|---|---|
-| Small (< 620px) | Hidden (burger fixed top-left) | Full width, 64px left margin clears burger | Full width, padded |
+| Small (< 620px) | Hidden (burger fixed top-left) | Full width, 64px left margin clears burger | Fills remaining shell width |
 | Medium (tablet) | Rail visible (flex column, left) | Fills remaining width, layout clears rail automatically | Fills remaining width after rail |
-| Large (desktop) | Rail visible, tray pushes | Fills remaining width, layout clears rail automatically | Fills remaining width, max-width constrained |
+| Large (desktop) | Rail visible, tray pushes | Fills remaining width, layout clears rail automatically | Fills remaining width |
 
 The `.app-shell` is a flex row. The AppTray's rail participates in the flex flow. The `.app` region is a bounded column: the app bar keeps its intrinsic height and `<main>` owns the remaining viewport height and vertical scrolling. The shell does not use compensating padding or fixed content heights.
 
-**Dimensions (grid-derived):**
-
-| Dimension | Formula | Resolves to |
-|---|---|---|
-| Content padding (small) | `var(--freefall-space-2)` | 1rem |
-| Content padding (medium+) | `var(--freefall-space-4)` | 2rem |
-| Content max-width (large) | `calc(120 * var(--freefall-space-1))` | 60rem |
-
-Top bar dimensions and styling are defined in the app-bar spec (`specs/design-system/app-bar/spec.md`).
+AppShell owns the scaffold, viewport bounding, `<main>` scroll ownership, and
+the named `content` inline-size query container. It intentionally does not add
+content padding, gutters, columns, or readable measure. A consumer-provided
+ContentGrid owns those content-layout concerns. Top bar dimensions and styling
+are defined in the app-bar spec (`specs/design-system/app-bar/spec.md`).
 
 **Props:**
 
@@ -104,6 +100,14 @@ Top bar dimensions and styling are defined in the app-bar spec (`specs/design-sy
 | `title` | `string` | yes | Page `<title>` and top bar title |
 | `navItems` | `NavItem[]` | yes | Passed through to AppTray |
 | `brandHref` | `string` | no | Passed through to AppTray for brand logo link |
+
+`NavItem` requires `icon`, `label`, and `href`; accepts optional `active`,
+`variant: "nav" | "uplink"`, and `subItems`. Each sub-item requires `label` and
+`href` and accepts optional `active`. AppShell currently passes the navigation
+fields understood by AppTray; AppTray's full contract is documented in its spec.
+
+**Slots:** the default slot is page content rendered directly in `<main>`. The
+named `head` slot appends page-specific elements to `<head>` after the title.
 
 **Component structure:**
 
@@ -120,21 +124,23 @@ The shell imports `base.css`. Pages using the shell do not need to import it.
 - **No content-aware shell** — The shell does not know what page it renders. It provides structure and slots.
 - **No fixed pixel dimensions** — All padding and sizing derive from spacing tokens.
 - **No shell without navigation** — The shell always includes AppTray. Pages without navigation should not use the shell.
-- **No layout logic in pages** — Padding, max-width, and content positioning are shell concerns. Pages provide content, not structure.
+- **No content layout in the shell** — Consumers provide ContentGrid or another content wrapper for gutters, measure, columns, and breakouts.
 
 ## Contract
 
 ### Definition of Done
 
-- [ ] `AppShell.astro` provides full document skeleton with AppBar, AppTray, and content slot
+- [x] `AppShell.astro` provides full document skeleton with AppBar, AppTray, and content slot
 - [ ] Both apps use the shell as their base layout on all pages
-- [ ] Top app bar is rendered via the `AppBar` component (see app-bar spec)
-- [ ] Content pane (`<main>`) declares `container-type: inline-size` and `container-name: content` for content-grid container queries
-- [ ] Content pane fills the viewport below the app bar and is the shell's only vertical scroll owner
-- [ ] Content area shifts when rail is visible (medium+) and when tray pushes (desktop)
-- [ ] Named `head` slot allows page-specific `<head>` content
+- [x] Top app bar is rendered via the `AppBar` component (see app-bar spec)
+- [x] Content pane (`<main>`) declares `container-type: inline-size` and `container-name: content` for consumer queries
+- [x] Content pane fills the viewport below the app bar and is the shell's vertical scroll owner
+- [x] Content area participates in the scaffold flex geometry when rail/tray width changes
+- [x] Named `head` slot allows page-specific `<head>` content
+- [x] AppShell leaves gutters and readable measure to a consumer ContentGrid
+- [x] Design-system demo has a representative `/app-shell/` page
 - [ ] No duplicate `<html>`, `<head>`, or `base.css` imports across pages
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
 
 ### Regression Guardrails
 
@@ -156,6 +162,12 @@ Scenario: Content responds to tray on desktop
   Given: Viewport is 780px or above
   When: The user opens the tray
   Then: The top bar and content pane shift right as the tray pushes into the flex row
+
+Scenario: Medium overlay does not define push behavior
+  Given: Viewport is between 620px and 779px
+  When: The user opens the tray
+  Then: The drawer and scrim establish an overlay contract
+  And: The overlay contract makes no promise that content geometry remains fixed or is pushed
 
 Scenario: Content owns remaining viewport height
   Given: A page contains more content than fits below the app bar

--- a/specs/design-system/app-tray/spec.md
+++ b/specs/design-system/app-tray/spec.md
@@ -4,7 +4,7 @@
 
 ### Context
 
-The app tray is the primary navigation surface for FREE//FALL. It follows the Material 3 navigation drawer pattern — a collapsible side panel that adapts across breakpoints from a full-screen modal on small viewports to a persistent rail + tray on large ones. A hamburger button with a micro-interaction animation (menu/close morph) controls the open/closed state at every breakpoint.
+The app tray is the primary navigation surface for FREE//FALL. It follows the Material 3 navigation drawer pattern: a collapsible side panel that adapts from a viewport-capped modal drawer on small viewports to a persistent rail and tray on larger ones. A hamburger button with a bar-to-cross micro-interaction controls the open/closed state at every breakpoint.
 
 The component is built with progressive enhancement: all layout, toggle, transitions, and scrim work with pure HTML + CSS. A small inline script adds keyboard support (Escape to close) and focus trap (modal overlay mode) as enhancements.
 
@@ -16,7 +16,7 @@ Parent spec: `specs/design-system/spec.md`
 
 | Viewport | Breakpoint | Closed state | Open state |
 |---|---|---|---|
-| Small (default) | < 620px | Hidden (off-screen) | Full-screen overlay |
+| Small (default) | < 620px | Hidden (off-screen) | Modal drawer, 320px wide and capped by viewport |
 | Medium (tablet) | >= 620px | Navigation rail | Full drawer (overlay on content) |
 | Large (desktop) | >= 780px | Navigation rail | Tray (pushes content) |
 
@@ -58,11 +58,14 @@ The tray has a persistent HTML open/closed state with associated pointer control
 | Tray item rail padding | `calc(1.5 * var(--freefall-space-1))` | 12px horizontal |
 | Minimized Button Size | `calc(6 * var(--freefall-space-1))` | 48px square |
 
-*Math note on perfect center alignment*: To ensure the `TrayButton` icons align perfectly under the center axis of the `HamburgerButton` (which sits at `16px` left + `24px` radius = `40px` center), the `.app-tray__nav` enforces a precisely matching `12px` horizontal boundary padding. In minimized state, buttons force a `48px` absolute square using an auto-margin that resolves to `4px`. (`12px` nav padding + `4px` margin = `16px` button left edge, mirroring the Hamburger button perfectly).
+The drawer itself is the inline-size query container. Its horizontal padding
+leaves a query box at or below the shared `64px` threshold in rail mode, so
+TrayButton and DrawerBrand collapse without receiving expanded state.
 
 **Hamburger button micro-interaction:**
 
-The hamburger icon animates between `menu` and `close` states using a CSS transition. Uses the Material Symbols Sharp `menu` and `close` ligatures. The transition morphs between the two glyphs via opacity crossfade — no custom SVG path animation. Driven entirely by checkbox `:checked` state.
+Three structural bars morph into a sharp skewed cross from checkbox `:checked`
+state. See the HamburgerButton spec for its prop and motion contract.
 
 **Surface styling:**
 
@@ -81,14 +84,13 @@ The tray is an Astro component — server-rendered HTML + CSS with a small inlin
 
 | File | Contents |
 |---|---|
-| `src/components/AppTray.astro` | Astro component — checkbox toggle, main container acting as both rail and tray, scrim, inline script |
-| `src/styles/app-tray.css` | Layout, dimensions, responsive rules, width transitions — all driven by `:has(:checked)` |
+| `src/components/AppTray.astro` | Astro component — AppTray composition, co-located layout/styles, scrim, and progressive enhancement script |
 
 **What works without JavaScript:**
 
 - Hamburger toggle (checkbox + label)
 - Drawer slide-in/out transitions
-- Hamburger icon crossfade
+- Hamburger bar morph
 - Scrim display and click-to-close (label for same checkbox)
 - All responsive modes (rail, overlay, push)
 
@@ -107,7 +109,7 @@ When the tray is open on small or medium viewports (where it overlays content), 
 
 - Tray slide: `transform` with `200ms ease-out` (open), `150ms ease-in` (close)
 - Scrim fade: `opacity` with matching duration
-- Hamburger crossfade: `150ms`
+- Hamburger bar transition: `270ms` (see HamburgerButton)
 
 **Keyboard and accessibility (progressive enhancement):**
 
@@ -117,6 +119,18 @@ When the tray is open on small or medium viewports (where it overlays content), 
 - Focus trap when tray is open as overlay (small + medium) — requires JS
 - Closing by toggle, scrim, or `Escape` restores focus to the toggle
 - Reduced-motion preference suppresses tray and toggle transitions
+
+**Props:**
+
+| Prop | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `items` | `NavItem[]` | yes | — | Ordered primary navigation items |
+| `brandHref` | `string` | no | DrawerBrand default | Publisher link destination |
+
+Each `NavItem` requires `icon`, `label`, and `href`; accepts `active`,
+`variant: "nav" | "uplink"`, and `subItems`. Each sub-item requires `label` and
+`href` and accepts `active`. Active primary items set `aria-current` and gate
+their TrayLinkGroup; active sub-items set `aria-current` on TrayLink.
 
 ### Contextual navigation
 
@@ -140,31 +154,30 @@ The demo (`apps/design-system/src/pages/app-tray-subsite.astro`) is a navigation
 - **No fixed pixel widths** — All dimensions derive from `--freefall-space-1`. No raw px or rem values in the CSS.
 - **No z-index wars** — Define tray and scrim z-index as component-scoped custom properties, not global magic numbers.
 - **No content-aware logic** — The tray is a navigation component. It accepts nav items via props but does not own page layout or wrap page content.
-- **No custom hamburger SVG** — Use Material Symbols Sharp ligatures (`menu` / `close`).
+- **No custom hamburger SVG or icon glyph swap** — HamburgerButton uses structural bars.
 - **No wrapping page content** — The tray renders alongside page content, not around it. The Astro page owns its layout.
 
 ## Contract
 
 ### Definition of Done
 
-- [ ] `AppTray.astro` renders a responsive navigation tray with rail, full drawer, and hamburger toggle
-- [ ] Toggle, transitions, and scrim work without JavaScript
-- [ ] Small viewport: tray is hidden by default, opens as full-screen overlay
-- [ ] Medium viewport: rail visible by default, tray opens as overlay
-- [ ] Large viewport: rail visible by default, tray opens and pushes content
-- [ ] Hamburger button animates between menu/close states
-- [ ] All dimensions use `calc()` with `--freefall-space-1` — no raw px/rem
-- [ ] Scrim renders on small + medium when tray is open; click-to-close works without JS
-- [ ] Focus trap active when tray overlays content (progressive enhancement)
-- [ ] Keyboard activation and expanded state remain synchronized (progressive enhancement)
-- [ ] Opening an overlay moves focus inside; closing by any supported method restores focus to the trigger
-- [ ] `Escape` key closes the tray (progressive enhancement)
-- [ ] Reduced-motion preference suppresses decorative transitions
-- [ ] Transitions match specified durations
-- [ ] Demo app has an app-tray reference page showing the component at all breakpoints
-- [ ] Demo app shows a scoped ("subsite") `navItems` configuration whose first item is an `arrow_back` uplink, rendering with the same rail/overlay/push behavior as the global nav
+- [x] `AppTray.astro` renders a responsive navigation tray with rail, drawer, and hamburger toggle
+- [x] Toggle, transitions, and scrim work without JavaScript
+- [x] Small viewport: tray is hidden by default and opens as a 320px capped modal drawer
+- [x] Medium viewport: rail visible by default, tray opens with overlay and scrim
+- [x] Large viewport: rail visible by default, tray opens in flex flow and pushes content
+- [x] Hamburger button morphs structural bars between menu and cross states
+- [x] Component dimensions derive from spacing tokens
+- [x] Scrim renders on small + medium when tray is open; click-to-close works without JS
+- [x] Focus trap active when tray overlays content (progressive enhancement)
+- [x] Keyboard activation and expanded state remain synchronized (progressive enhancement)
+- [x] Opening an overlay moves focus inside; closing by supported controls restores focus to the trigger
+- [x] `Escape` key closes the tray (progressive enhancement)
+- [x] Reduced-motion preference suppresses decorative transitions
+- [x] Demo app has an app-tray reference page documenting all breakpoints
+- [x] Demo app links to a scoped navigation pattern with an `arrow_back` uplink
 - [ ] Playwright e2e tests cover all Scenarios against build artifacts
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
 
 ### Regression Guardrails
 
@@ -174,7 +187,7 @@ The demo (`apps/design-system/src/pages/app-tray-subsite.astro`) is a navigation
 - Scrim must not render on desktop (tray pushes content instead of overlaying)
 - Core toggle must work without JavaScript — do not introduce JS dependencies for open/close state
 - Do not duplicate DOM nodes for rail icons and drawer icons — use the unified `TrayButton` to handle responsive states
-- **State Logic**: Do not use `[data-state]` attributes to pass the expanded state down to buttons. Use CSS Container Queries (`@container`) pointing at `.app-tray__rail-column`'s `inline-size` to allow fluid geometric expansion.
+- **State Logic**: Do not pass expanded state to child components. Use the drawer's inline-size query container and the current `64px` threshold.
 - **Icon Alignment**: Do not use arbitrary margin values to align icons. Rely on strict math equating the exact center axis computed from the fixed `HamburgerButton`'s radius + absolute left positioning.
 
 ### Scenarios
@@ -184,10 +197,10 @@ Scenario: Small viewport — tray hidden by default
   When: The page loads
   Then: No tray or rail is visible; only the hamburger button is rendered
 
-Scenario: Small viewport — tray opens as full-screen overlay
+Scenario: Small viewport — tray opens as capped modal drawer
   Given: Viewport width is below 620px
   When: The user clicks the hamburger button
-  Then: The tray slides in as a full-screen overlay with scrim behind it
+  Then: A 320px-wide drawer capped by the viewport slides in with a scrim behind it
 
 Scenario: Medium viewport — rail visible by default
   Given: Viewport width is between 620px and 779px
@@ -198,6 +211,7 @@ Scenario: Medium viewport — tray opens as overlay
   Given: Viewport width is between 620px and 779px
   When: The user clicks the hamburger button
   Then: The tray expands from the rail to full width (20rem) as an overlay with scrim
+  And: Overlay describes stacking and modality; it does not establish a push-behavior guarantee
 
 Scenario: Large viewport — rail visible, tray pushes content
   Given: Viewport width is 780px or above
@@ -232,7 +246,7 @@ Scenario: Scrim click closes the tray
 Scenario: Hamburger micro-interaction
   Given: The tray is closed
   When: The user clicks the hamburger button
-  Then: The icon crossfades from `menu` to `close` within 150ms
+  Then: Three structural bars morph into a sharp cross
 
 Scenario: Tray renders a scoped subsite nav set
   Given: The layout supplies a scoped `navItems` array whose first item is an `arrow_back` uplink

--- a/specs/design-system/callout/spec.md
+++ b/specs/design-system/callout/spec.md
@@ -20,9 +20,15 @@ Parent spec: `specs/design-system/spec.md`
 
 The callout visualizes structural separation using surface depth elevation, typography voice splits, and a background watermark:
 - **Container (`.callout`):** Step up depth elevation using the primary elevated surface (`--freefall-bg-surface-1`) with sharp edges (`border-radius: 0`) and no border outlines.
-- **Header (`.callout-header`):** Convey status/warning metadata using the uppercase Monospace font and the isotope-yellow accent (`--freefall-color-accent-400`).
+- **Header (`.callout-header`):** Convey status/warning metadata using uppercase monospace and `--freefall-alert-base`.
 - **Body (`.callout-body`):** Render explanations and rules prose in the standard clean sans-serif typeface to optimize readability.
-- **Background Watermark (`.callout::after`):** Support category classification (via `data-icon` attribute mapping to Material Symbols ligatures) rendered as a large, faint background symbol in the top-left corner using the primary contrast tone (`--freefall-color-primary-700` at `0.35` opacity).
+- **Background Watermark (`.callout::after`):** Render `priority_high` by default or the optional `data-icon` Material Symbols ligature as a large top-left watermark using `--freefall-border-strong` at `0.35` opacity.
+
+This is a class-based HTML primitive, not a prop-driven Astro component. Its
+full author contract is `.callout` on the root, optional `data-icon`, optional
+`.callout-header`, and required content in `.callout-body`. The root supplies
+token-derived padding and vertical margins; header and body are layered above
+the non-interactive watermark.
 
 
 ### Markdown Integration
@@ -44,11 +50,11 @@ To write callouts within standard Markdown files (`.md`), authors write raw HTML
 
 ### Definition of Done
 
-- [ ] `packages/design-system/src/styles/callout.css` implements callout styling.
-- [ ] `packages/design-system/src/styles/base.css` imports the callout stylesheet.
-- [ ] Demo app lists and documents Callouts at `/callout/`.
+- [x] `packages/design-system/src/styles/callout.css` implements callout styling.
+- [x] `packages/design-system/src/styles/base.css` imports the callout stylesheet.
+- [x] Demo app lists and documents Callouts at `/callout/`.
 - [ ] Preface page uses the callout HTML structure.
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass.
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass.
 
 ### Usage Guidelines
 

--- a/specs/design-system/content-grid/spec.md
+++ b/specs/design-system/content-grid/spec.md
@@ -4,13 +4,13 @@
 
 ### Context
 
-The app shell's content pane currently has basic padding and a `max-width` cap. Game content — particularly the core rulebook — needs a structured layout that provides:
+The app shell's content pane originally had basic padding and a `max-width` cap. The content grid replaced that arrangement with a structured layout that provides:
 
 1. A **main column** (67ch) for primary content (prose, rules text)
 2. An optional **side column** for supplementary content (tables, infoboxes, images)
 3. Responsive behavior that collapses the side column when space is insufficient
 
-The content grid is a CSS Grid layout applied inside `<main>` (in `AppShell.astro`). It replaces the current `max-width` constraint with a grid-based content measure, and its main column (67ch) supersedes `.freefall-prose`'s `max-width: 65ch`.
+The content grid is a CSS Grid layout applied inside `<main>` (in `AppShell.astro`). It owns the 67ch rich-text measure; typography contributes element styling under `main` but no competing wrapper or measure.
 
 Parent spec: `specs/design-system/spec.md`
 
@@ -72,18 +72,19 @@ At the base tier, all content — including items targeting the side — flows i
 | *(default)* | `main` | Main column |
 | `.content-side` | `side` | Falls into main column |
 | `.content-wide` | `main-start / side-end` | Full main column |
+| `.breakout` | `main-start / side-end` | Main column |
 
-At the base tier, `.content-side` and `.content-wide` items stay in the main column since the side column does not exist.
+At the base tier, `.content-side`, `.content-wide`, and `.breakout` items stay in the main column since the side column does not exist. At two-column tiers `.content-wide` and `.breakout` both span the main and side columns; `.content-wide` additionally opts into horizontal overflow containment at the base tier.
 
 **Authoring pattern — pairing a side note with main content:**
 
-Every direct child of `.content-grid` is its own grid item on its own implicit row. A lone `.content-side` therefore occupies a row by itself: the side column shows the note, and the main column shows an empty hole of the same height.
+Every direct child of `.content-grid` is a grid item. Auto-placement can place an adjacent main-column item and `.content-side` item on the same implicit row; a side item without paired main content leaves the main cell on its row empty.
 
 To place a side note *beside* flowing text, wrap the run of main content in a plain `<div>` (one grid item) and put the `.content-side` element **immediately after it** — the two items share a grid row, and the note top-aligns with the wrapped block (`align-self: start`). `content/core-rulebook/chapters/01-world.md` and `content/scenarios/northern-lights/a-01-the-story-so-far.md` are the reference uses. On the base tier the note falls into the main flow after the wrapped block.
 
 **Wide content overflow (base tier):**
 
-`.content-wide` elements (e.g., large tables) may exceed the 67ch main column at base tier. To prevent layout breakage, `.content-wide` gets `overflow-x: auto` so oversized content scrolls horizontally within the main column rather than overflowing the viewport.
+`.content-wide` elements (e.g., large tables) may exceed the 67ch main column at base tier. `.content-wide` gets `overflow-x: auto`, making horizontal scrolling available when its contents actually overflow. Browser and platform scrollbar presentation varies, so a permanently visible scrollbar is not guaranteed.
 
 **Tokens (CSS custom properties):**
 
@@ -109,25 +110,25 @@ Gutters and gap reuse existing spacing tokens (`--freefall-space-2` and `--freef
 
 `<main>` (in `AppShell.astro`) gains `container-type: inline-size` and `container-name: content`. The content grid CSS uses `@container content (inline-size >= ...)` to switch between tiers. Container queries are required (not media queries) because the content pane's available width depends on the nav tray state, not just viewport width.
 
-**Changes to app-shell:**
+**App-shell integration:**
 
-| Current | After |
+| Before content grid | Current |
 |---|---|
 | `max-width: calc(120 * var(--freefall-space-1))` on `<main>` (in `AppShell.astro`) | Removed — the grid template defines width constraints |
 | Horizontal padding on `<main>` (in `AppShell.astro`) | Removed — the grid's gutter columns handle edge spacing |
 | Vertical padding on `<main>` (in `AppShell.astro`) | Unchanged |
 | No container declaration | `container-type: inline-size; container-name: content` |
 
-**Relationship to `.freefall-prose`:**
+**Relationship to typography:**
 
-The content grid's 67ch main column replaces `.freefall-prose`'s `max-width: 65ch` as the content measure. `.freefall-prose` will be removed in a future pass once the main content grid is active on all content pages.
+The content grid's 67ch main column is the sole rich-text measure. Typography scopes naked rich-text element styles to `main`; no prose wrapper class is part of the contract.
 
 **Demo page:**
 
 The design system demo app gets a `content-grid` page (`apps/design-system/src/pages/content-grid.astro`) showing:
 
-- All three tiers with sample content in main and side columns
-- Each placement class (default, `.content-side`, `.content-wide`)
+- Responsive main and side content whose live tier follows the available page width
+- Each placement class (default, `.content-side`, `.content-wide`, `.breakout`)
 - How tier transitions look when the viewport / tray state changes
 
 ### Anti-Patterns
@@ -141,24 +142,23 @@ The design system demo app gets a `content-grid` page (`apps/design-system/src/p
 
 ### Definition of Done
 
-- [ ] `src/styles/tokens.css` defines `--freefall-content-main`, `--freefall-content-side-wide`, `--freefall-content-side-narrow`
-- [ ] `src/styles/content-grid.css` implements the three-tier responsive grid with container queries
-- [ ] Placement classes (`.content-side`, `.content-wide`) work in all three tiers
-- [ ] At base tier, side-targeted content falls back to the main column without overflow or hidden content
-- [ ] `.content-wide` has `overflow-x: auto` so oversized content (e.g., wide tables) scrolls horizontally at base tier
-- [ ] `<main>` (in `AppShell.astro`) declares `container-type: inline-size` in `AppShell.astro` scoped styles
-- [ ] Current `max-width` and horizontal padding on `<main>` (in `AppShell.astro`) removed
-- [ ] `content-grid.css` imported via `base.css`
-- [ ] Design system demo app has a `content-grid` page demonstrating all tiers and placement classes
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] `src/styles/tokens.css` defines `--freefall-content-main`, `--freefall-content-side-wide`, `--freefall-content-side-narrow`
+- [x] `src/styles/content-grid.css` implements the three-tier responsive grid with container queries
+- [x] Placement classes (`.content-side`, `.content-wide`, `.breakout`) work across responsive tiers
+- [x] At base tier, side-targeted content falls back to the main column without hidden content
+- [x] `.content-wide` has `overflow-x: auto` so oversized content can scroll horizontally at base tier
+- [x] `<main>` declares `container-type: inline-size` in `AppShell.astro` scoped styles
+- [x] `<main>` has no competing `max-width` or horizontal padding
+- [x] `content-grid.css` is imported via `base.css`
+- [x] Design system demo app has a live responsive `content-grid` page demonstrating all placement classes
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
 
 ### Regression Guardrails
 
 - Main column must never exceed 67ch at any tier
 - Side column must not appear when the container is too narrow to fit it alongside the main column
-- Placement fallback: `.content-side` and `.content-wide` items must be visible (not hidden, clipped, or overflowing) at all tiers
+- Placement fallback: `.content-side`, `.content-wide`, and `.breakout` items must remain visible at all tiers; overflowing `.content-wide` content must remain horizontally reachable
 - Grid gutters must use spacing tokens, never raw values
-- Gutters must remain wider than the browser scrollbar (~15–17px); even the narrow gutter `--freefall-space-2` (1rem / 16px) satisfies this
 - Container query breakpoints must account for gutters and gap — no content clipping at tier boundaries
 
 ### Scenarios
@@ -192,11 +192,11 @@ Scenario: Wide content spans both columns
 Scenario: Wide content scrolls at base tier
   Given the grid is in the base (single-column) tier
   When a .content-wide element (e.g., a wide table) exceeds 67ch
-  Then the element shows a horizontal scrollbar within the main column
+  Then horizontal scrolling is available within the main column when the content overflows
   And the page layout does not overflow horizontally
 
-Scenario: Demo page shows all tiers
+Scenario: Demo page responds through all tiers
   Given the design system demo app is built
   When a developer navigates to the content-grid page
-  Then all three tiers are demonstrated with sample content in main and side placements
+  Then resizing the content pane demonstrates the applicable base, narrow-side, and wide-side tiers with main, side, wide, and breakout placements
 ```

--- a/specs/design-system/design-tokens/attribute-colors/spec.md
+++ b/specs/design-system/design-tokens/attribute-colors/spec.md
@@ -61,7 +61,7 @@ Parent spec: `specs/design-system/design-tokens/spec.md`
 | `--freefall-attr-ghost` | `accent-400` | Ghost attribute foreground |
 | `--freefall-attr-ghost-bg` | `accent-900` | Ghost attribute background |
 
-**Consumer update:** `GearCard.astro` binding circles should migrate from hardcoded palette references (`--freefall-color-primary-600`, `--freefall-color-accent-400`, `--freefall-color-primary-200`) to the new semantic tokens (`--freefall-attr-body`, `--freefall-attr-mind`, `--freefall-attr-ghost`). Text color on each circle should be chosen for contrast against the new backgrounds.
+**Consumer:** `GearCard.astro` delegates binding circles to `StatCircle.astro`, which consumes the foreground and background attribute tokens. Text color on each circle is chosen from the paired semantic tokens.
 
 ### Dependencies
 
@@ -77,11 +77,11 @@ Parent spec: `specs/design-system/design-tokens/spec.md`
 
 ### Definition of Done
 
-- [ ] `tokens.css` defines `--freefall-color-body-{400,900}` and `--freefall-color-mind-{400,900}` base palette tokens
-- [ ] `tokens.css` defines all 6 `--freefall-attr-*` semantic tokens referencing the correct base palette values
-- [ ] GearCard binding circles use `--freefall-attr-body`, `--freefall-attr-mind`, `--freefall-attr-ghost` semantic tokens
-- [ ] DS docs token page shows the new attribute color swatches
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm typecheck` pass
+- [x] `tokens.css` defines `--freefall-color-body-{400,900}` and `--freefall-color-mind-{400,900}` base palette tokens
+- [x] `tokens.css` defines all 6 `--freefall-attr-*` semantic tokens referencing the correct base palette values
+- [x] `StatCircle` uses the paired Body, Mind, and Ghost semantic tokens for GearCard binding circles
+- [x] DS docs token page shows the attribute color swatches
+- [x] `pnpm build`, `pnpm lint`, and `pnpm typecheck` pass
 
 ### Regression Guardrails
 
@@ -93,7 +93,7 @@ Parent spec: `specs/design-system/design-tokens/spec.md`
 
 ```
 Scenario: Body binding circle uses Flare Orange
-  Given: An GearCard with binding { body: 2 }
+  Given: A GearCard with binding { body: 2 }
   When: Rendered
   Then: The Body circle background resolves to hsl(18, 90%, 55%)
 

--- a/specs/design-system/design-tokens/spec.md
+++ b/specs/design-system/design-tokens/spec.md
@@ -4,7 +4,7 @@
 
 ### Context
 
-Design tokens define the visual vocabulary of FREE//FALL: colors, breakpoints, and (eventually) spacing, typography, and elevation. They are the lowest layer of the design system — consumed by styles, components, and apps. The theme is "deep space cobalt" — ceramic surfaces, void darks, and harsh neon contrast.
+Design tokens define the visual vocabulary of FREE//FALL: colors, breakpoints, spacing, typography, and content dimensions. They are the lowest layer of the design system, consumed by styles, components, and apps. CSS custom properties in `tokens.css` are the sole token source; there is no TypeScript token layer, barrel export, or parity requirement.
 
 Parent spec: `specs/design-system/spec.md`
 
@@ -62,6 +62,8 @@ clipping technique requires one-pixel geometry.
 | `--freefall-text-display` | `primary-50` | Headings, hero text |
 | `--freefall-text-body` | `primary-100` | Body copy |
 | `--freefall-text-muted` | `primary-200` | Secondary / disabled text with normal-text contrast |
+| `--freefall-text-high` | `primary-50` | Explicit high-emphasis text |
+| `--freefall-text-link` | `accent-500` | Link marker and definition emphasis |
 | `--freefall-border-subtle` | `primary-800` | Dividers, low-contrast borders |
 | `--freefall-border-strong` | `primary-700` | High-contrast borders |
 | `--freefall-action-base` | `primary-500` | Buttons, links (default) |
@@ -85,7 +87,7 @@ clipping technique requires one-pixel geometry.
 
 ### Anti-Patterns
 
-- **No semantic tokens referencing other semantic tokens** — Semantic tokens alias base palette values only. No indirection chains.
+- **No semantic color aliases referencing other semantic tokens** — Semantic color aliases reference base palette values only. Composite non-color tokens such as text shadows are documented separately.
 - **No base palette in component CSS** — Components use semantic tokens. The palette is an internal detail.
 - **No hardcoded color values in components** — Every color must come from a token. If a needed color doesn't exist, add a token first.
 - **No opacity hacks for color variants** — Each needed shade gets its own palette step. Do not use `rgba()` or `opacity` to derive variants from existing tokens.
@@ -94,16 +96,16 @@ clipping technique requires one-pixel geometry.
 
 ### Definition of Done
 
-- [ ] `src/styles/tokens.css` defines all base palette and semantic custom properties listed above
-- [ ] Semantic tokens reference base palette tokens via `var()` — no hardcoded values
-- [ ] `src/styles/base.css` imports `tokens.css`
-- [ ] Demo app has a token reference page showing all colors with their names and values
+- [x] `src/styles/tokens.css` defines all base palette and semantic custom properties listed above
+- [x] Semantic color tokens reference base palette tokens via `var()`
+- [x] `src/styles/base.css` imports `tokens.css`
+- [x] Demo app shows every base palette and public semantic color token listed above; other token families have representative demos on their owning pages
 - [ ] `--freefall-text-muted` meets WCAG AA for normal text on canvas and supported surfaces
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
 
 ### Regression Guardrails
 
-- Semantic tokens must only reference base palette custom properties
+- Semantic color aliases must only reference base palette custom properties
 - No color value may appear in a component or style file that isn't a `var(--freefall-*)` reference
 - Normal-size semantic text tokens maintain at least 4.5:1 contrast on their supported backgrounds
 
@@ -114,7 +116,7 @@ Scenario: Base palette renders correctly
   When: An element uses `var(--freefall-bg-canvas)`
   Then: The element background is `hsl(220, 43%, 3%)`
 
-Scenario: Demo page shows full palette
+Scenario: Demo page shows color tokens
   Given: The demo app is built
   When: A developer navigates to the tokens page
-  Then: All base palette and semantic tokens are rendered as labeled color swatches
+  Then: All base palette and public semantic color tokens listed in this spec are rendered as labeled color swatches

--- a/specs/design-system/drawer-brand/spec.md
+++ b/specs/design-system/drawer-brand/spec.md
@@ -33,25 +33,29 @@ The entire strip is a single `<a>` element wrapping the logo and caption. This k
 
 **Responsive behaviour — CSS Container Query:**
 
-The component reuses the same container-query pattern as `TrayButton`. The `app-tray__rail-column` already declares `container-type: inline-size`. When the container is narrow (rail), the caption text is hidden; when the container is wide (tray open), the caption is revealed.
+The component reuses the same container-query pattern as `TrayButton`. The
+AppTray `.drawer` declares `container-type: inline-size`. When its query box is
+narrow, the caption is visually hidden; when it is wider, the caption appears.
 
 ```
-@container (max-width: 160px) → hide caption, center logo
-@container (min-width: 161px) → show caption beside logo
+@container (max-width: 64px) → hide caption, center logo
+@container (min-width: 64.01px) → show caption beside logo
 ```
 
 No media queries — all layout shifts are driven by the parent container width.
 
 **Placement inside AppTray:**
 
-The component renders as the last child inside `.app-tray__rail-column`, below the `<nav>`. It is pushed to the bottom via `margin-top: auto` on the component's root element (the `.app-tray__rail-column` is already `display: flex; flex-direction: column`).
+The component renders as the last child of AppTray's flex-column `.drawer`.
+The preceding `.nav` uses `flex: 1`, so the brand occupies the drawer's bottom
+position while navigation owns and scrolls the remaining space.
 
 **Component structure:**
 
 | File | Contents |
 |---|---|
 | `src/components/DrawerBrand.astro` | Astro component — `<a>` wrapper, inline SVG logo, caption text |
-| `src/styles/drawer-brand.css` | Layout, container-query rules, spacing, link reset |
+Styles are co-located in `DrawerBrand.astro`.
 
 **Props:**
 
@@ -63,25 +67,29 @@ The component renders as the last child inside `.app-tray__rail-column`, below t
 
 | Dimension | Formula | Resolves to |
 |---|---|---|
-| Logo size | `calc(6 * var(--freefall-space-1))` | 3rem (48px) |
+| Logo size | `calc(4 * var(--freefall-space-1))` | 2rem (32px) |
 | Strip padding | `var(--freefall-space-2)` | 1rem (16px) |
 | Gap (logo ↔ text) | `var(--freefall-space-2)` | 1rem (16px) |
-| Bottom margin | `var(--freefall-space-2)` | 1rem (16px) |
 
 **Logo rendering:**
 
-The Myrrys logo SVG (`src/assets/myrrys-logo.svg`) is imported with `?raw` and rendered inline via `set:html`. The SVG contains two `<path>` elements with gradient fills (yellow-to-orange, `#ccda0b` → `#eda01b`) that define the brand identity. CSS must not override these fills — the logo renders with its native gradients at all times.
+The Myrrys logo SVG (`src/assets/myrrys-logo.svg`) is imported with `?raw` and
+rendered inline via `set:html`. Its two paths use the same solid `#EDA01B` fill.
+CSS does not override that native fill. The mark has a thin link-colored border
+and token-derived inset padding.
 
 **Caption text:**
 
 Two lines inside a `<span>`, styled with the `.text-caption` editorial class:
 
 ```
-© Kustannusosakeyhtiö Myrrys
+© Myrrys 2026
 MIT / CC-BY
 ```
 
 The text uses `var(--freefall-text-muted)` colour and `letter-spacing: 0.05em` (inherited from `.text-caption`). The line break is a `<br>` — no dynamic layout.
+The fixed accessible name is `Kustannusosakeyhtiö Myrrys`, preserving
+the full publisher name independently of the compact visible copy.
 
 **Link styling:**
 
@@ -94,30 +102,30 @@ The `<a>` wrapper resets text-decoration and inherits colour. On `:hover` / `:fo
 - **No separate rail/tray DOM** — One set of elements adapts via container query. Do not duplicate the logo or conditionally render different markup for rail vs tray.
 - **No raw px/rem values** — All dimensions derive from `--freefall-space-1`.
 - **No framework island** — Astro component, server-rendered. No client-side JS.
-- **No CSS fill overrides on the logo** — The Myrrys logo uses intentional brand gradients. Do not override `fill` with `currentColor` or any other value.
+- **No CSS fill overrides on the logo** — Preserve the source SVG's solid fill.
 - **No content duplication** — The licence text lives only in this component. The about page explains the terms; the component merely links to it.
 
 ## Contract
 
 ### Definition of Done
 
-- [ ] `DrawerBrand.astro` renders inside `AppTray` as the last child of `.app-tray__rail-column`
-- [ ] `href` prop defaults to `"/about"` and is configurable by consuming apps
-- [ ] Rail mode (container ≤ 160px): only the nine-tail logo is visible, centered
-- [ ] Open mode (container > 160px): logo and caption text appear side-by-side
-- [ ] Caption reads "© Kustannusosakeyhtiö Myrrys" / "MIT / CC-BY" with `.text-caption` styling
-- [ ] The entire strip is a single `<a>` element — accessible click target
-- [ ] Logo renders with its native gradient fills (yellow-to-orange brand colours preserved)
-- [ ] All dimensions use `calc()` with `--freefall-space-1` — no raw px/rem
-- [ ] Container-query driven — no media queries in `drawer-brand.css`
-- [ ] Hover/focus states provide visible feedback with accent outline
-- [ ] `drawer-brand.css` is imported via `base.css`
-- [ ] Design-system demo app has a `/drawer-brand` reference page
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] `DrawerBrand.astro` renders inside `AppTray` as the final child after the flexible nav
+- [x] `href` prop defaults to `"/about"` and is configurable by consuming apps
+- [x] Rail mode (query box ≤ 64px): only the logo is visible and centered
+- [x] Open mode (query box > 64px): logo and caption text appear side-by-side
+- [x] Caption reads "© Myrrys 2026" / "MIT / CC-BY" with `.text-caption` styling
+- [x] The entire strip is a single `<a>` element
+- [x] Logo renders with its native solid fill
+- [x] Dimensions derive from spacing tokens
+- [x] Container-query driven with no component media query
+- [x] Hover and keyboard focus provide visible feedback; focus has an accent outline
+- [x] Styles are co-located in `DrawerBrand.astro`
+- [x] Design-system demo app has a `/drawer-brand/` reference page with real query containers
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
 
 ### Regression Guardrails
 
-- The branding strip must never overlap or push nav items out of view — it sits below them with `margin-top: auto`
+- The branding strip must never overlap nav items; the flexible, scrollable nav precedes it
 - Logo must remain visible in rail mode — do not hide the entire component when the tray is collapsed
 - Link must be keyboard-focusable and have a visible focus indicator
 - Caption must not wrap to a third line at tray width (320px) — verify the Finnish publisher name fits
@@ -133,7 +141,7 @@ Scenario: Rail mode — logo only
 Scenario: Open mode — logo and caption
   Given: The AppTray is open (full tray width)
   When: The drawer expands
-  Then: The caption text "© Kustannusosakeyhtiö Myrrys" / "MIT / CC-BY" appears to the right of the logo
+  Then: The caption text "© Myrrys 2026" / "MIT / CC-BY" appears to the right of the logo
 
 Scenario: Link navigates to about page (app)
   Given: The DrawerBrand is rendered in `@free-fall/app` with default `href`

--- a/specs/design-system/gear-card/spec.md
+++ b/specs/design-system/gear-card/spec.md
@@ -53,7 +53,8 @@ All internal spacing derives from `--freefall-space-1`.
      - Weapon: `DV {n}` + `{harm_type}`
      - Armor: `AV {n}` + `{av_type}`
      - Augmentation: `{augmentation_category}` + `{integration}`
-     - Vehicle: `Frame {n}` / `Systems {n}` / `AV {n}` / `Size: {size_category}`
+      - Exo: `Frame {n}` / `Sys {n}` / `AV {n}` / `{size_category}`
+      - Vehicle: `Frame {n}` / `Sys {n}` / `AV {n}` / `{size_category}`
      - Utility: (no category stats row)
    - **Qualities list** — Each quality as a single line, preceded by a bullet. `.text-ui-small`.
 
@@ -70,6 +71,24 @@ Props:
 | `mind` | `number` | No | `undefined` | Mind binding cost. Omitted or `0` → disabled (∅) |
 | `ghost` | `number` | No | `undefined` | Ghost binding cost. Omitted or `0` → disabled (∅) |
 | `image` | `ImageMetadata \| string` | No | `undefined` | Astro `ImageMetadata` for optimized images, or string URL for passthrough. Falls back to category icon. |
+
+`GearData` always requires `title`, `qualities: string[]`, and a category;
+`nickname` is optional. Category-specific fields are:
+
+| Category | Required fields |
+|---|---|
+| `weapon` | `dv`, `harm_type: "Physical" \| "Psychic"` |
+| `armor` | `av`, `av_type` |
+| `augmentation` | `augmentation_category: "Spliced" \| "Bionic" \| "Cybernetic"`, `integration: "Invasive" \| "Field-Operable"` |
+| `utility` | no additional fields |
+| `exo` | `frame`, `systems`, `pilot_binding`, `vehicle_av`, `size_category` |
+| `vehicle` | `frame`, `systems`, `pilot_binding`, `vehicle_av`, `size_category` |
+
+`pilot_binding` contains numeric `body`, `mind`, and `ghost` values.
+`size_category` is `"Personal" | "Small" | "Medium" | "Large" | "Huge"`.
+Fallback icons are `swords`, `shield`, `biotech`, `handyman`, and
+`rocket_launch`; exo intentionally shares `rocket_launch` with vehicle until a
+distinct approved symbol exists.
 
 #### Component Location
 
@@ -93,14 +112,14 @@ Scoped `<style>` block — no new CSS file in `styles/`. The card is self-contai
 
 ### Definition of Done
 
-- [ ] `GearCard.astro` renders all 5 gear categories correctly (weapon, armor, augmentation, utility, vehicle)
-- [ ] All three binding StatCircles (Body, Mind, Ghost) always render; omitted or zero-value props appear as disabled (∅)
-- [ ] Card dimensions maintain 5:7 ratio at all viewport widths (does not reflow — fixed size)
-- [ ] Image zone uses `aspect-ratio: 16 / 9`; accepts `ImageMetadata` (Astro optimized) or string URL
-- [ ] Fallback icon displays when no `image` prop is provided
-- [ ] Shader overlay covers entire image zone with attribute-tinted gradient (single binding) or primary fallback
-- [ ] `.text-ui-small` qualities list does not overflow the card (scrolls or truncates)
-- [ ] Component passes `pnpm typecheck` with strict category narrowing (no `any` casts)
+- [x] `GearCard.astro` renders all 6 categories (weapon, armor, augmentation, utility, exo, vehicle)
+- [x] All three binding StatCircles always render; omitted or zero-value props appear as void (∅)
+- [x] Card uses fixed 32 by 44.5 spacing-unit dimensions
+- [x] Image zone uses `aspect-ratio: 16 / 9`; accepts `ImageMetadata` or string URL
+- [x] Every category has an intentional fallback icon, with exo sharing vehicle's icon
+- [x] Shader overlay covers the image zone with a single-binding tint or action-base fallback
+- [x] Qualities live in the scrolling stats zone
+- [x] Component passes `pnpm typecheck` with strict category narrowing (no `any` casts)
 - [ ] Visual regression: card renders identically in Chromium and Firefox
 
 ### Regression Guardrails
@@ -151,6 +170,12 @@ Scenario: Vehicle card stats
   Given: <GearCard data={vehicle} /> where vehicle has frame 3, systems 2, vehicle_av 1, size_category "Medium"
   When: Rendered
   Then: Stats zone shows "Frame 3 · Sys 2 · AV 1 · Medium"
+
+Scenario: Exo card and fallback
+  Given: <GearCard data={exo} /> where exo has category "exo" and no image
+  When: Rendered
+  Then: Stats zone renders the exo FRM/SYS/AV/size data
+  And: Image zone renders the intentional rocket_launch fallback icon
 
 Scenario: Single-attribute shader tint
   Given: <GearCard data={augmentation} ghost={3} />

--- a/specs/design-system/hamburger-button/spec.md
+++ b/specs/design-system/hamburger-button/spec.md
@@ -34,6 +34,14 @@ The parallel bars become a sharp skewed cross rather than a soft rotated icon. T
 | Icon lines color | `--freefall-text-body` |
 | Hover surface background | `--freefall-action-hover` |
 
+**Props:**
+
+| Prop | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `id` | `string` | no | `"hamburger-toggle"` | Internal checkbox id and trigger id prefix |
+| `controls` | `string` | no | — | Id exposed through `aria-controls` |
+| `label` | `string` | no | `"Toggle navigation"` | Trigger accessible name |
+
 **Component structure:**
 
 | File | Contents |
@@ -52,19 +60,18 @@ The parallel bars become a sharp skewed cross rather than a soft rotated icon. T
 
 ### Definition of Done
 
-- [ ] `HamburgerButton.astro` provides the HTML scaffold for a pure-CSS boolean toggle.
-- [ ] Co-located `<style>` block manages the 48px rounded M3 target container and nested bars.
-- [ ] Checkbox `:checked` CSS handles the transition to the close state.
-- [ ] Middle bar compresses horizontally to the right via `transform-origin: right` and `scaleX(0.15)` bounding, shifting to the accent color.
-- [ ] Top and bottom bars form an X using `translateY` offset and `skewY` (45deg / -45deg).
-- [ ] Left and right limits of all expanding/skewing bars act as perfectly vertical bounds.
-- [ ] Bars utilize sharp 0px border-radius edges.
-- [ ] The visible trigger exposes button semantics, its controlled region, and synchronized expanded state when JavaScript is available.
-- [ ] Enter and Space activate the focused trigger; focus remains visibly indicated.
-- [ ] Motion is suppressed when the user requests reduced motion.
-- [ ] Demo app mounts a reference subpage testing the toggle in standalone isolation.
+- [x] `HamburgerButton.astro` provides the HTML scaffold for a CSS boolean toggle.
+- [x] Co-located style manages the 48px rounded target and nested bars.
+- [x] Checkbox `:checked` CSS handles the transition to the close state.
+- [x] Middle bar compresses toward the right and shifts to the link color.
+- [x] Top and bottom bars form a cross using translate and skew transforms.
+- [x] Bars use sharp zero-radius edges.
+- [x] The visible trigger exposes button semantics, controlled region, and synchronized expanded state with JavaScript.
+- [x] Enter and Space activate the focused trigger; focus remains visibly indicated.
+- [x] Reduced motion reduces transition duration.
+- [x] Demo app mounts a standalone reference page.
 - [ ] Playwright e2e tests cover all Scenarios against build artifacts.
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` tasks pass cleanly.
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` tasks pass cleanly.
 
 ### Regression Guardrails
 

--- a/specs/design-system/iconography/spec.md
+++ b/specs/design-system/iconography/spec.md
@@ -62,6 +62,11 @@ Icons inherit `color` and scale with `font-size` from their parent.
 | `src/styles/typography.css` | Updated — adds `.material-symbols-sharp` base class |
 
 No separate `IconLinks` component — icons load through the same `FontLinks` component since both are Google Fonts resources.
+`FontLinks` accepts no props and exposes no slots; consumers render icon
+ligature markup directly.
+Rendering an icon adds no component JavaScript: it is text styled by the loaded
+font. Pages and layouts may still contain scripts for unrelated interactive
+components.
 
 ### Anti-Patterns
 
@@ -75,13 +80,14 @@ No separate `IconLinks` component — icons load through the same `FontLinks` co
 
 ### Definition of Done
 
-- [ ] `FontLinks.astro` includes the Material Symbols Sharp stylesheet `<link>` tag with `display=block`
-- [ ] `typography.css` defines the `.material-symbols-sharp` base class
-- [ ] Demo app has an iconography reference page showing sample icons at various sizes
-- [ ] Icons are accessible — ligature text is readable by screen readers
-- [ ] Icons inherit color and scale with font-size
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
-- [ ] Built HTML contains the Material Symbols stylesheet `<link>` tag and zero `<script>` tags
+- [x] `FontLinks.astro` includes the Material Symbols Sharp stylesheet `<link>` tag with `display=block`
+- [x] `typography.css` defines the `.material-symbols-sharp` base class
+- [x] Demo app has an iconography reference page showing sample icons at various sizes
+- [x] Standalone ligature text remains available to assistive technology; decorative icons can be hidden
+- [x] Icons inherit color and scale with font-size
+- [x] Icon rendering itself adds no JavaScript
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [ ] Built HTML contains the Material Symbols stylesheet `<link>` tag
 
 ### Regression Guardrails
 

--- a/specs/design-system/spacing/spec.md
+++ b/specs/design-system/spacing/spec.md
@@ -28,12 +28,9 @@ Token names use the multiplier, not the computed value — `space-4` means "4 ba
 
 | File | Contents |
 |---|---|
-| `src/styles/tokens.css` | Spacing CSS custom properties (added to existing token file) |
-| `src/tokens/spacing.ts` | TypeScript constants for spacing values |
+| `src/styles/tokens.css` | Canonical spacing CSS custom properties |
 
-**Token duality:**
-
-CSS and TypeScript values must stay in sync, following the same pattern as colors and breakpoints.
+CSS custom properties are the sole token source. There is no TypeScript token module, barrel export, or parity test.
 
 ### Anti-Patterns
 
@@ -45,19 +42,15 @@ CSS and TypeScript values must stay in sync, following the same pattern as color
 
 ### Definition of Done
 
-- [ ] `src/styles/tokens.css` defines `--freefall-space-1` through `--freefall-space-16`
-- [ ] `src/tokens/spacing.ts` exports spacing values as TypeScript constants
-- [ ] Rem values in CSS and TypeScript match exactly
-- [ ] `src/index.ts` barrel exports the spacing tokens
-- [ ] Unit tests verify all TypeScript spacing values
-- [ ] Demo app has a spacing reference page showing all steps with visual rulers
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] `src/styles/tokens.css` defines `--freefall-space-1` through `--freefall-space-16`
+- [x] CSS custom properties are the sole source for spacing tokens
+- [x] Demo app has a spacing reference showing all steps with visual rulers
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
 
 ### Regression Guardrails
 
-- Spacing CSS and TypeScript values must stay in sync
 - Token names use the multiplier (1, 2, 4, 8, 16), not the computed rem value
-- No spacing value may appear in a component or style file that isn't a `var(--freefall-space-*)` reference
+- Production dimensions derive from spacing tokens, subject to the literal-length exceptions in the design-token spec
 
 ### Scenarios
 
@@ -65,11 +58,6 @@ Scenario: Spacing tokens resolve correctly
   Given: `tokens.css` is imported via `base.css`
   When: An element uses `padding: var(--freefall-space-4)`
   Then: The computed padding is `2rem`
-
-Scenario: Token duality holds
-  Given: `spacing.ts` defines `space4` as `"2rem"`
-  When: `tokens.css` defines `--freefall-space-4`
-  Then: Both values are identical rem strings
 
 Scenario: Demo page shows spacing scale
   Given: The demo app is built

--- a/specs/design-system/spec.md
+++ b/specs/design-system/spec.md
@@ -1,10 +1,12 @@
 # Feature: Design System
 
+**Implements:** `docs/architecture/ADR-2026-07-19-design-system-contract-boundaries.md`
+
 ## Blueprint
 
 ### Context
 
-The design system is the single source of styling truth for FREE//FALL. It provides tokens, CSS styles, and components consumed by all apps in the monorepo. The goal is a cohesive visual language that ships zero JavaScript by default and leans on native web platform capabilities wherever possible.
+The design system is the single source of styling truth for FREE//FALL. It provides CSS custom-property tokens, CSS styles, and components consumed by all apps in the monorepo. The goal is a cohesive visual language that avoids a framework client runtime by default and leans on native web platform capabilities wherever possible. Inline JavaScript is allowed for progressive enhancement.
 
 **Brand and taste live in [`DESIGN.md`](../../DESIGN.md)** (repo root) — the design language document. Component specs define contracts; `DESIGN.md` defines what makes a component *look like FREE//FALL*. Read it before designing anything new.
 
@@ -14,8 +16,9 @@ The design system is the single source of styling truth for FREE//FALL. It provi
 
 | Layer | Format | Purpose |
 |---|---|---|
-| Styles | Plain CSS files | Tokens (custom properties), resets, base styles, component styles — mobile-first |
-| Components | `.astro` files | Composition wrappers only when plain HTML + CSS is insufficient |
+| Foundation | Plain CSS files | Tokens (custom properties), reset, typography — mobile-first |
+| Global primitives | Plain CSS files | Content grid, surfaces, callouts, and small utilities |
+| Components | `.astro` files | Self-contained composition when plain HTML + CSS is insufficient |
 
 No build step. Source is distributed directly to consuming apps via Vite aliases.
 The package owns an `astro check` script so source-distributed components are
@@ -27,23 +30,20 @@ An Astro SSG site that imports from `packages/design-system` and renders every e
 
 **Consumption model:**
 
-Astro server-renders all components to static HTML + CSS. There is no client-side JS bundle to tree-shake. This means:
+Astro server-renders all components to static HTML + CSS. Components may emit small inline progressive-enhancement scripts, but no framework client runtime is included by default. This means:
 
 - **CSS files**: Not tree-shaken. An imported CSS file is included in full. This is fine — global styles and tokens are small and needed everywhere.
 - **Astro components**: Only rendered components produce output. Unused imports cost nothing.
 
-The recommended pattern is a **base layout** in each app that imports the full design system styles once. Components are imported individually in pages/components that use them — this is a template necessity, not an optimization.
+`AppShell` owns the one-time `base.css` import and renders `FontLinks` in the document head. Components are imported individually in pages/components that use them; consumers of `AppShell` must not duplicate either foundation dependency.
 
 ```astro
 ---
-// Base layout — import styles once here
-import "@free-fall/design-system/styles/base.css";
+// Base layout — AppShell owns base.css and FontLinks
+import AppShell from "@free-fall/design-system/components/AppShell.astro";
 ---
 
-<html lang="en">
-  <head><slot name="head" /></head>
-  <body><slot /></body>
-</html>
+<AppShell title="FREE//FALL" navItems={navItems}><slot /></AppShell>
 ```
 
 ```astro
@@ -95,15 +95,16 @@ The preflight lives in `src/styles/preflight.css` and is imported first in `base
 
 ### Definition of Done
 
-- [ ] `packages/design-system` exports at least one token, one CSS file, and one component
-- [ ] `apps/design-system` demos every exported feature on at least one page
-- [ ] `pnpm build` succeeds for both `apps/free-fall` and `apps/design-system`
-- [ ] `pnpm typecheck` checks `packages/design-system` Astro source and both apps
-- [ ] `pnpm test` passes all design system unit tests
-- [ ] `pnpm test:e2e` passes both app and living-styleguide Playwright suites
-- [ ] No `workspace:*` references in any `package.json`
-- [ ] Zero JavaScript in the demo app build output (unless a Svelte island is present)
-- [ ] Design system package has no dependency on any app
+- [x] `packages/design-system` provides CSS custom-property tokens, global CSS, and Astro components
+- [x] `AppShell` owns the `base.css` import and `FontLinks` rendering
+- [x] `apps/design-system` demos every current global style and component on at least one page
+- [x] `pnpm build` succeeds for both `apps/free-fall` and `apps/design-system`
+- [x] `pnpm typecheck` checks `packages/design-system` Astro source and both apps
+- [x] `pnpm test` passes all design system unit tests
+- [x] `pnpm test:e2e` passes both app and living-styleguide Playwright suites
+- [x] No `workspace:*` references in any `package.json`
+- [x] Demo builds contain no framework client runtime unless an explicit island requires one; inline progressive-enhancement scripts are allowed
+- [x] Design system package has no dependency on any app
 
 ### Regression Guardrails
 
@@ -137,15 +138,15 @@ import AppShell from "@free-fall/design-system/components/AppShell.astro";
 
 ### Scenarios
 
-Scenario: New CSS component added
+Scenario: New global CSS primitive added
   Given: A new CSS file is added to `packages/design-system/src/styles/`
   When: It is imported in `apps/design-system`
-  Then: The demo app builds and renders the styled elements with zero JS
+  Then: The demo app builds and renders the styled elements without requiring a framework client runtime
 
 Scenario: New Astro component added
   Given: A new `.astro` file is added to `packages/design-system/src/components/`
   When: It is imported via `@free-fall/design-system/components/Button.astro`
-  Then: Vite alias resolves it, the demo app renders it, and no JS is shipped
+  Then: Vite alias resolves it, the demo app renders it, and no framework client runtime is shipped unless explicitly required
 
 Scenario: Token added
   Given: A new CSS custom property is added to `packages/design-system/src/styles/tokens.css`

--- a/specs/design-system/stat-circle/spec.md
+++ b/specs/design-system/stat-circle/spec.md
@@ -100,13 +100,14 @@ Type modifier classes (`.stat-circle--body`, etc.) override only `--_sc-bg` and 
 
 ### Definition of Done
 
-- [ ] StatCircle renders all three types (body, mind, ghost) with correct attribute colors
-- [ ] Disabled state renders `∅` in cobalt colors when `disabled` is true or `value` is null
-- [ ] Bound state shows solid foreground color with glow; disabled circles ignore `bound`
-- [ ] Optional `attribute` label renders below the circle, uppercase, max 5 chars, `.text-ui-small`
-- [ ] Custom sizing via `--freefall-stat-circle-size` scales circle and value text proportionally
-- [ ] Component passes `pnpm typecheck`
-- [ ] Design system demo page at `/stat-circle/` exercises all variants
+- [x] StatCircle renders all three types with their attribute colors
+- [x] Void and disabled states render `∅` in neutral colors
+- [x] Void hides an attribute label while explicit disabled preserves it
+- [x] Bound state shows solid foreground color with glow; disabled circles ignore `bound`
+- [x] Optional visible label is uppercase, max 5 chars, and `.text-ui-small`
+- [x] Custom sizing via `--freefall-stat-circle-size` scales circle and value text proportionally
+- [x] Component passes `pnpm typecheck`
+- [x] Design system demo page at `/stat-circle/` exercises void, disabled, bound, zero, labels, and sizing
 
 ### Regression Guardrails
 

--- a/specs/design-system/tray-button/spec.md
+++ b/specs/design-system/tray-button/spec.md
@@ -6,7 +6,8 @@
 
 The Tray Button is an interactive navigation component specifically designed for use within the application's sidebar (AppTray). It dynamically adapts its layout based on the parent tray's state: showing just an icon when the tray is minimized (on tablet/desktop), and an icon alongside a text label when the tray is fully open (across all screen sizes). This behavior mirrors modern dashboard and chat interfaces (e.g., Gemini).
 
-In aligning with the FREE//FALL design system, the transition between minimized and open states should be managed as gracefully as possible, favoring CSS-driven layout changes based on the parent container's state (e.g., via CSS container queries or parent data attributes).
+The minimized/open presentation is CSS-driven from the parent query box. No
+expanded-state prop or data attribute is part of the contract.
 
 Parent spec: `specs/design-system/spec.md`
 
@@ -15,7 +16,7 @@ Parent spec: `specs/design-system/spec.md`
 **State management:**
 
 The component's visual presentation (minimized vs. open) is strictly dictated by the width of its parent container using CSS Container Queries (`@container`).
-- When the parent container is narrow (e.g., `<= 160px` during the AppTray minimized rail state), the button hides its text label and removes internal flex gaps, shrinking down to display only the geometrically centered icon.
+- When the nearest inline-size query container is `<= 64px`, the button visually hides its text label, removes the gap, and renders a centered 48px target.
 - When the parent container expands, the button natively expands into its fluid geometry, displaying both its icon and the text label.
 
 **Visual Design & Sizing:**
@@ -30,6 +31,16 @@ The component's visual presentation (minimized vs. open) is strictly dictated by
 
 `variant?: "nav" | "uplink"` (default `"nav"`). The `uplink` variant renders the exit from a subsite scope (see `specs/design-system/app-tray/spec.md#contextual-navigation`): text and icon use `--freefall-text-muted` (restored to `--freefall-text-display` on hover/focus), and an `::after` hairline separator (`--freefall-border-subtle`) draws below the button so the uplink reads as "up a level" rather than a sibling page. Added 2026-07-06 after visual review: with uplink and chapters rendered identically, the two were indistinguishable in the rail.
 
+**Props:**
+
+| Prop | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `icon` | `string` | yes | — | Material Symbols Sharp ligature |
+| `label` | `string` | yes | — | Visible and accessible destination label |
+| `href` | `string` | yes | — | Link destination |
+| `active` | `boolean` | no | falsy | Sets `aria-current="page"` and filled icon styling |
+| `variant` | `"nav" \| "uplink"` | no | `"nav"` | Selects ordinary destination or scope-exit presentation |
+
 **Component structure:**
 
 | File | Contents |
@@ -38,7 +49,7 @@ The component's visual presentation (minimized vs. open) is strictly dictated by
 
 ### Anti-Patterns
 
-- **Hardcoded JavaScript Resize Checks**: The component should not observe window width via JavaScript to toggle the label, nor rely on data attribute toggles (`[data-state]`) that CSS cannot naturally animate. Rely entirely on fluid CSS logic (CSS Container Queries `@container`).
+- **Hardcoded JavaScript Resize Checks**: The component must not observe window width or consume inert state attributes. Rely on the nearest inline-size query container.
 - **Text Wrapping**: Text should not wrap to a second line when the container width diminishes. Overflows must be aggressively controlled (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap;`).
 - **Inaccessible Icon-only States**: When the label is visually hidden in minimized mode, the button must still expose its intent to screen readers (e.g., using `aria-label` or visually-hidden utility classes), ensuring it does not become an unlabeled icon button.
 
@@ -46,15 +57,15 @@ The component's visual presentation (minimized vs. open) is strictly dictated by
 
 ### Definition of Done
 
-- [ ] `TrayButton.astro` provides the HTML scaffold for rendering an icon and text label.
-- [ ] Co-located `<style>` block manages the flex layout, gaps, and padding using design system tokens.
-- [ ] When the parent context dictates a minimized tray, the text label is visually hidden, centering the icon.
-- [ ] Implements `white-space: nowrap` and `overflow: hidden` to handle text bounds strictly.
-- [ ] Employs accessible labeling so screen readers recognize the button context regardless of visual layout.
-- [ ] Defines interactive state styling (hover/focus/active) mirroring other interactive components.
-- [ ] Demo app mounts a reference section testing the button in simulated open and closed tray environments.
+- [x] `TrayButton.astro` renders an icon and text label inside a link.
+- [x] Co-located style manages flex layout, gaps, and token-derived padding.
+- [x] At a query box width of 64px or less, the label is visually hidden and the icon target is centered.
+- [x] Label uses no-wrap, overflow hiding, and ellipsis.
+- [x] Visually hidden label remains in the accessibility tree.
+- [x] Hover, focus, current-page, and uplink states have distinct styling.
+- [x] Demo uses real inline-size query containers and includes uplink and current-page states.
 - [ ] Playwright e2e tests cover all Scenarios against build artifacts.
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` tasks pass cleanly.
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` tasks pass cleanly.
 
 ### Scenarios
 
@@ -64,7 +75,7 @@ Scenario: Open Tray State
   Then: The button prominently displays both the icon and the text label adjacent to each other.
 
 Scenario: Minimized Tray State (Desktop/Tablet)
-  Given: The AppTray is collapsed to its minimized state (narrow container width)
+  Given: The nearest inline-size query container is 64px or narrower
   When: The user views the Tray Button
   Then: Only the icon is visible, the container gap is `0`, and the button forces a strict `48px` width/height to perfectly align center with external toggles.
 

--- a/specs/design-system/tray-link-group/spec.md
+++ b/specs/design-system/tray-link-group/spec.md
@@ -6,7 +6,9 @@
 
 The Tray Link Group specifies the pattern for secondary/nested navigation links in the AppTray. As seen in interfaces like the Gemini web UI and other Material 3 implementations, these inner links appear dynamically when the tray is opened and are hidden when the tray operates as a minimized rail. On mobile viewports (where the tray is fully expanded as an overlay), they are visible by default. 
 
-In FREE//FALL, this pattern will be used to display an index of `core-rules` articles directly within the opened drawer, allowing immediate navigation without loading an intermediate index page. It relies entirely on CSS and progressive enhancement, fitting into the existing design system architecture cleanly.
+In FREE//FALL, the group is gated by both navigation context and geometry. The
+consumer sets `active` only for the current primary location; CSS then hides
+that active group's links in a rail-sized query box.
 
 Parent spec: `specs/design-system/spec.md`
 
@@ -15,8 +17,9 @@ Parent spec: `specs/design-system/spec.md`
 **State management:**
 
 Similar to `TrayButton`, the visibility of `TrayLinkGroup` is strictly driven by CSS Container Queries (`@container`) targeting the parent container's `inline-size`.
-- **Minimized (Rail):** When the tray is collapsed (e.g. width `<= 64px`), the secondary links are removed from the layout context (e.g., `display: none` or `visibility: hidden`) or structurally collapsed to avoid clutter and prevent them from being reachable by keyboard.
-- **Open (Tray):** When the container fluidly expands, the links are revealed.
+- **Inactive primary location:** `active` defaults false and the group is `display: none` at every width.
+- **Minimized (Rail):** At query box width `<= 64px`, even an active group is `display: none`.
+- **Open (Tray):** Above 64px, an active group is displayed.
 
 **Visual Design & Sizing:**
 
@@ -33,6 +36,25 @@ Similar to `TrayButton`, the visibility of `TrayLinkGroup` is strictly driven by
 | `packages/design-system/src/components/TrayLinkGroup.astro` | Renders a semantic nested list structure (`<ul>`, `<li>`) that houses the secondary links. Co-located `<style>` block owns visibility via `@container` query logic, indentation. |
 | `packages/design-system/src/components/TrayLink.astro` | Individual link component within the group, providing semantic `<a>` tags and localized text truncation. Co-located `<style>` block owns hierarchical typography rules and interaction states. |
 
+**Props:**
+
+TrayLinkGroup:
+
+| Prop | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `ariaLabel` | `string` | no | `"Secondary Navigation"` | Accessible list label |
+| `active` | `boolean` | no | `false` | Allows the group to display for the current primary location |
+
+Its default slot accepts list-item content, normally TrayLink instances.
+
+TrayLink:
+
+| Prop | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `href` | `string` | yes | — | Link destination |
+| `label` | `string` | yes | — | Visible destination label |
+| `active` | `boolean` | no | falsy | Sets `aria-current="page"` |
+
 ### Anti-Patterns
 
 - **JavaScript Observer Dependencies:** Do not depend on JavaScript event listeners to toggle visibility when resizing or opening the tray. All geometric layout shifts must be CSS-driven via `@container`.
@@ -44,14 +66,15 @@ Similar to `TrayButton`, the visibility of `TrayLinkGroup` is strictly driven by
 
 ### Definition of Done
 
-- [ ] `TrayLinkGroup.astro` and `TrayLink.astro` are implemented.
-- [ ] Component renders a semantic nested list of secondary links.
-- [ ] CSS Container Queries (`@container`) are exclusively used to show the links in expanded mode and collapse them entirely (hiding from view and layout) in minimized rail mode.
-- [ ] Links are styled with smaller typography and clear truncation (ellipsis) preventing layout warp on long article titles.
-- [ ] Nested links are unreachable via keyboard (tab order) when the tray is minimized.
-- [ ] Demo app mounts a reference page (`tray-link-group.astro`) that tests the group within simulated `<div data-tray-state="open">` and `<div data-tray-state="minimized">` contexts.
+- [x] `TrayLinkGroup.astro` and `TrayLink.astro` are implemented.
+- [x] Components render a semantic list with list items and links.
+- [x] `active` gates group visibility before geometry is considered.
+- [x] A `64px` query-box threshold hides active groups in rail mode.
+- [x] Links use smaller typography and truncate long labels with ellipsis.
+- [x] Hidden groups use `display: none`, removing links from tab order.
+- [x] Demo uses real inline-size query containers rather than inert state attributes.
 - [ ] Playwright e2e tests cover all specified Scenarios.
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass optimally.
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass.
 
 ### Regression Guardrails
 

--- a/specs/design-system/typography/spec.md
+++ b/specs/design-system/typography/spec.md
@@ -14,7 +14,7 @@ Parent spec: `specs/design-system/spec.md`
 
 | Role | Family | Google Fonts ID | CSS custom property |
 |---|---|---|---|
-| Body / display | Lato | `Lato:wght@300;400;700` | `--freefall-font-body` |
+| Body / display | Lato | `Lato:wght@300;400;700;900` | `--freefall-font-body` |
 | UI / contrast | IBM Plex Mono | `IBM+Plex+Mono:wght@400;500` | `--freefall-font-mono` |
 
 **Font stack fallbacks:**
@@ -53,11 +53,12 @@ import FontLinks from "@free-fall/design-system/components/FontLinks.astro";
 
 **Font loading strategy:**
 
-The `FontLinks` component emits three `<link>` tags in this order:
+The `FontLinks` component emits four `<link>` tags in this order:
 
 1. `<link rel="preconnect" href="https://fonts.googleapis.com">` — early connection to API
 2. `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>` — early connection to font files
 3. `<link rel="stylesheet" href="...&display=swap">` — the font stylesheet
+4. `<link rel="stylesheet" href="...Material+Symbols+Sharp&display=block">` — the sharp icon font
 
 The `display=swap` parameter ensures text is immediately visible in the fallback font stack while web fonts load. This prevents Flash of Invisible Text (FOIT) and limits Cumulative Layout Shift (CLS) to a brief swap. No additional `font-display` overrides are needed in CSS — Google Fonts embeds the `font-display: swap` rule in the served `@font-face` declarations.
 
@@ -77,34 +78,33 @@ Instead of generic abstract headings, FREE//FALL uses a strict editorial scale t
 | `.text-section` | Large, distinct | `<h2>` equivalents, major rules sections |
 | `.text-subsection` | Medium, structural | `<h3>` equivalents, granular rules blocks |
 | `.text-body-lead` | Slightly enlarged body | Intro paragraphs, chapter summaries |
-| `.text-copy` | Base body size (1rem) | Standard paragraphs (`<p>`) |
+| `.text-copy` | Base body size (1.125rem) | Standard paragraphs (`<p>`) |
 | `.text-caption` | Small, loose tracking | Figure captions, subtle notes |
-| `.text-callout` | Thematic, visually distinct | Flavor text, in-universe quotes |
-| `.text-ui` | Standard UI size (1rem) | Primary buttons, app bars, tabs |
+| `.text-ui` | Standard UI size (1.125rem) | Primary buttons, app bars, tabs |
 | `.text-ui-small` | Small UI size (0.875rem) | Secondary navigation, badges, metadata |
 
 *Note: `p` elements receive standard body styling by default. The `.text-copy` class is only needed to apply paragraph typography to non-`p` nodes.*
 
 **Emphasis & Color Classes:**
 
-Three levels of text emphasis mapped to the ceramic highlight colors:
+Two text emphasis utilities map to ceramic highlight colors:
 
 | Class | Color token | Palette step |
 |---|---|---|
 | `.text-high` | `--freefall-text-display` | primary-50 |
-| `.text-low` | `--freefall-text-muted` | primary-300 |
+| `.text-low` | `--freefall-text-muted` | primary-200 |
 
 Use `.text-high` or `.text-low` on any element to override its default color.
 
-**Prose Scoping for Markdown (`.freefall-prose`):**
+**Rich-text scoping (`main`):**
 
-When rendering raw Markdown bodies (like long-form rulebooks), do not attempt to map utility classes to every single generated HTML node. Instead, wrap the output in a `<div class="freefall-prose">` scope container.
+`AppShell` renders page content inside `main`. Naked rich-text elements in that content area receive the editorial defaults without an additional wrapper class. Components outside `main` do not receive these rules.
 
-The `.freefall-prose` scope automatically:
-- Enforces an ergonomic `max-width: 65ch` measure to prevent unreadable widescreen text walls.
+The `main` scope automatically:
+- Leaves content measure to the page-level content grid, whose main column owns the 67ch reading measure.
 - Applies the correct vertical rhythm (margins that map to the `8px` base grid) between paragraphs and headings.
 - Automatically styles all naked `<h1>`, `<h2>`, and `<h3>` tags to the `.text-chapter`, `.text-section`, and `.text-subsection` scales respectively.
-- Styles `<pre>` with padding and a dark background (`--freefall-color-primary-700`) within `main`.
+- Styles `<pre>` with padding and a dark background (`--freefall-bg-surface-2`) within `main`.
 - Styles `<em>` with high-emphasis color (`--freefall-text-high`) and semi-bold weight within `main`.
 - Deep-styles TTRPG-specific nested structures natively:
   - **Lists**: Strictly indented padding for `<ul>` and `<ol>`, with unified vertical spacing for complex nested rules exceptions.
@@ -125,16 +125,16 @@ Note: `<pre>` and `<em>` element styles are intentionally scoped under `main` �
 
 ### Definition of Done
 
-- [ ] `src/components/FontLinks.astro` renders preconnect and stylesheet `<link>` tags for both fonts
-- [ ] `src/styles/typography.css` defines `--freefall-font-body` and `--freefall-font-mono` custom properties
-- [ ] `src/styles/typography.css` implements the detailed editorial scale utility classes (`.text-chapter`, `.text-section`, etc.) and the `.freefall-prose` comprehensive scope styles.
-- [ ] `src/styles/typography.css` adheres strictly to baseline rhythm (`line-height` evaluates to multiples of `var(--freefall-space-1)`).
-- [ ] `src/styles/base.css` imports `typography.css`
-- [ ] Both apps use `FontLinks` in their layouts
-- [ ] Demo app has a typography reference page showing both fonts, the editorial scales, and a mock `.freefall-prose` Markdown output.
+- [x] `src/components/FontLinks.astro` renders preconnect and stylesheet `<link>` tags for the text and icon fonts
+- [x] `src/styles/typography.css` defines `--freefall-font-body` and `--freefall-font-mono` custom properties
+- [x] `src/styles/typography.css` implements the editorial scale utility classes and comprehensive `main` rich-text scope styles
+- [x] Typography line heights derive from `var(--freefall-space-1)`
+- [x] `src/styles/base.css` imports `typography.css`
+- [x] `AppShell` renders `FontLinks`, covering both apps
+- [x] Demo app has a typography reference page showing representative font faces, classes, and naked rich-text output in `main`
 - [x] Demo app has a definition-list reference page (`/definition-list/`) showing the stacked and inline-strip variants, with e2e coverage (`apps/design-system/e2e/definition-list.test.ts`)
-- [ ] `pnpm build`, `pnpm lint`, and `pnpm test` pass
-- [ ] Built HTML contains Google Fonts `<link>` tags and zero `<script>` tags
+- [x] `pnpm build`, `pnpm lint`, and `pnpm test` pass
+- [x] Built HTML contains the Google Fonts `<link>` tags and no framework client runtime unless explicitly required
 
 ### Regression Guardrails
 
@@ -160,4 +160,4 @@ Scenario: Code elements use IBM Plex Mono
 Scenario: Typography demo page
   Given: The demo app is built
   When: A developer navigates to the typography page
-  Then: Both fonts are rendered with sample text at all defined weights
+  Then: Both fonts are rendered with representative samples and the implemented editorial classes are demonstrated


### PR DESCRIPTION
## Summary

Aligns the design system's documented contracts with what was actually built, ratified in a new ADR that supersedes the March 2026 component-model ADR. Also lands a few small, separable component changes surfaced during the alignment.

The component behavior itself (foundation contracts, StatCircle void state, overlay a11y) landed in earlier commits on this branch; the work here is the catch-up — specs, demos, tests, docs — plus two genuinely new features.

## Commits

- **feat(gear-card)** — treat `exo` as a distinct gear category (own icon + demo card)
- **fix(drawer-brand)** — hover / focus-visible affordances with a token-derived outline
- **feat(app-shell)** — expose the `uplink` nav variant through props + new app-shell demo page
- **test(stat-circle)** — unit + e2e coverage for the void state (null value without explicit disabled hides the label)
- **refactor(tray-link-group)** — `data-tray-state` → BEM modifier classes, e2e selectors updated
- **docs(design-system)** — ADR-2026-07-19 (foundation ownership, rich-text/measure split, global primitives, scoped-class encapsulation, progressive enhancement); superseded March ADR pointed forward; remaining specs + demo pages aligned

## ADR-2026-07-19 decisions

- `AppShell` owns foundation loading (base.css + FontLinks) for both apps
- `main` scopes rich-text; `.content-grid` owns measure — no required prose wrapper
- Global opt-in primitives (`.content-grid`, `.surface`, `.callout`) have a documented home
- BEM-like scoped class names are implementation details, not consumer API
- Progressive enhancement judged by baseline capability + runtime cost, not a blanket no-JS rule

## Verification

All four gates green:
- Lint (Biome) ✓
- Typecheck (astro check, 3 projects) ✓
- Unit tests — 48 passed ✓
- E2E (Playwright) — 50 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)